### PR TITLE
Don't treat gamepad axes as pairs.

### DIFF
--- a/src/gzgamepad.js
+++ b/src/gzgamepad.js
@@ -49,18 +49,16 @@ function updateGamepads() {
     }
 
     // Poll each axis
-    for (var i = 0; i < controller.gamepad.axes.length; i += 2) {
-      if (controller.prevAxes[i] !== controller.gamepad.axes[i] ||
-          controller.prevAxes[i+1] !== controller.gamepad.axes[i+1]) {
-        // Note that we update the axes *before* we call the user callback.
+    for (var i = 0; i < controller.gamepad.axes.length; i++) {
+      var axis = controller.gamepad.axes[i];
+
+      if (controller.prevAxes[i] !== axis) {
+        // Note that we update the axis *before* we call the user callback.
         // That's so that the user callback can, at its option, get the complete
         // current state of the controller by looking at the prevAxes.
-        controller.prevAxes[i] = controller.gamepad.axes[i];
-        controller.prevAxes[i+1] = controller.gamepad.axes[i+1];
+        controller.prevAxes[i] = axis;
 
-        onAxisCb(controller, {'index': (i/2).toFixed(0),
-                  'x': controller.gamepad.axes[i],
-                  'y': controller.gamepad.axes[i+1]});
+        onAxisCb(controller, {'index': i, 'axis': axis});
       }
     }
   }


### PR DESCRIPTION
It turns out that gamepad axes are not truly paired, at least,
not along even/odd pairs.  That is, on my gamepad here, the
left analog left/right is axis 0, and the left analog front/back
is axis 1.  But my right analog left/right is axis 3, and the
right analog front/back is axis 4.  So we shouldn't treat these
as pairs, instead just treat them all as individual axes.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>