### PR TITLE
Heightmap default values and style updates

### DIFF
--- a/src/FuelServer.ts
+++ b/src/FuelServer.ts
@@ -16,17 +16,16 @@ export const IGN_FUEL_HOST: string = 'fuel.ignitionrobotics.org';
  * @param {string} uri - A string to convert to a Fuel Server URI, if able.
  * @return The transformed URI, or the same URI if it couldn't be transformed.
  */
-export function createFuelUri(uri: string) {
+export function createFuelUri(uri: string): string {
   // Check to see if the modelName points to the Fuel server.
-  if (uri.indexOf('https://' + FUEL_HOST) !== 0) {
+  if (uri.indexOf('https://' + FUEL_HOST) !== 0 || uri.indexOf('https://' + IGN_FUEL_HOST) !== 0) {
     // Check to see if the uri has the form similar to
     // `/home/.../fuel.ignitionrobotics.org/...`
     // If so, then we assume that the parts following
     // `fuel.ignitionrobotics.org` can be directly mapped to a valid URL on
     // Fuel server
-    if (uri.indexOf(FUEL_HOST) > 0 || 
-        uri.indexOf(IGN_FUEL_HOST) > 0) {
-      var uriArray = uri.split('/').filter(function(element) {
+    if (uri.indexOf(FUEL_HOST) > 0 || uri.indexOf(IGN_FUEL_HOST) > 0) {
+      const uriArray = uri.split('/').filter(function(element) {
         return element !== '';
       });
       if (uri.indexOf(FUEL_HOST) > 0) {
@@ -68,7 +67,7 @@ export class FuelServer {
     // We still handle the response in a callback.
     // TODO(germanmas): We should update and use async/await instead throughout the library.
     const filesUrl = `${uri.trim()}/tip/files`;
-  
+
     // Make the request to get the files.
     fetch(filesUrl, { headers: this.requestHeader })
       .then(res => res.json())
@@ -77,24 +76,24 @@ export class FuelServer {
         callback(files);
       })
       .catch(error => console.error(error));
-  
+
     // Helper function to parse the file tree of the response into an array of
     // file paths. The file tree from the Server consists of file elements
     // that contain a name, a path and children (if they are a folder).
     function prepareURLs(fileTree: any, baseUrl: string): string[] {
       let parsedFiles: string[] = [];
-  
+
       for (var i = 0; i < fileTree.length; i++) {
         // Avoid the thumbnails folder.
         if (fileTree[i].name === 'thumbnails') {
           continue;
         }
-  
+
         // Loop through files to extract files from folders.
         extractFile(fileTree[i]);
       }
       return parsedFiles;
-  
+
       // Helper function to extract the files from the file tree.
       // Folder elements have children, while files don't.
       function extractFile(el: any): void {
@@ -103,7 +102,7 @@ export class FuelServer {
           if (el.name.endsWith('.config')) {
             return;
           }
-  
+
           var url = baseUrl + el.path;
           parsedFiles.push(url);
         } else {

--- a/src/Globals.ts
+++ b/src/Globals.ts
@@ -1,16 +1,22 @@
 import {Object3D} from 'three';
 
-export function getDescendants(obj: Object3D, array: Object3D[]): Object3D[] {
-  if (array === undefined) {
-    array = [];
-  }
-
-  Array.prototype.push.apply(array, obj.children);
-
-  for (var i = 0, l = obj.children.length; i < l; i++) {
-    getDescendants(obj.children[ i ], array );
-  }
-
+/**
+ * Given a ThreeJS Object, return all its children as an array.
+ * Notes:
+ * - We are using getDescendants as a way to maintain legacy code. We should use traverse() whenever possible.
+ * - We should discourage its use and move towards using traverse().
+ * @param obj The ThreeJS Object to get the descendants of.
+ * @param array Optional. An array that will store all the children.
+ * @returns An array of the children of the given ThreeJS Object (can be dismissed if the array argument is used).
+ */
+export function getDescendants(obj: Object3D, array: Object3D[] = []): Object3D[] {
+  obj.traverse((child) => {
+    // Note: This function is called on the obj as well.
+    // Since we just need its children, we filter the original object.
+    if (child !== obj) {
+      array.push(child);
+    }
+  });
   return array;
 };
 

--- a/src/SDFParser.ts
+++ b/src/SDFParser.ts
@@ -1,4 +1,4 @@
-import * as THREE from 'three'; 
+import * as THREE from 'three';
 // Nate disabled import *  as SPE from '../include/SPE';
 import { getDescendants } from './Globals';
 import { FuelServer,
@@ -53,10 +53,10 @@ export class SDFParser {
 
   private mtls = {};
   private textures = {};
-  
+
   // Flag to control the usage of PBR materials (enabled by default).
   private enablePBR: boolean = true;
-  
+
   // Should contain model files URLs if not using gzweb model files hierarchy.
   private customUrls: string[] = [];
   private parseXML: any;
@@ -72,21 +72,21 @@ export class SDFParser {
   * @param {Scene} scene - the gz3d scene object
   **/
   constructor(scene: Scene) {
-   
+
     // set the xml parser function
     this.parseXML = function(xmlStr: string) {
       return (new window.DOMParser()).parseFromString(xmlStr, 'text/xml');
     };
-  
+
     this.scene = scene;
     this.scene.setSDFParser(this);
     this.scene.initScene();
-    
+
     var that = this;
     this.emitter.on('material', function(mat) {
       that.materials = Object.assign(that.materials, mat);
     });
-  
+
     this.fuelServer = new FuelServer();
   }
 
@@ -102,7 +102,7 @@ export class SDFParser {
       console.warn('Trying to add invalid URL: ' + url);
       return;
     }
-  
+
     // Avoid duplicated URLs.
     if (this.customUrls.indexOf(trimmedUrl) === -1) {
       this.customUrls.push(trimmedUrl);
@@ -128,12 +128,12 @@ export class SDFParser {
         colorInput['a'] || 1
       ];
     }
-  
+
     color.r = parseFloat(values[0]);
     color.g = parseFloat(values[1]);
     color.b = parseFloat(values[2]);
     color.a = parseFloat(values[3]);
-  
+
     return color;
   }
 
@@ -200,7 +200,7 @@ export class SDFParser {
     let outerAngle: number = 0.0;
     let falloff: number = 0.0;
     let type: number = 1;
-  
+
     if (light.attenuation)
     {
       if (light.attenuation.range)
@@ -244,7 +244,7 @@ export class SDFParser {
     var L = attLin;
     var Q = attQuad;
     var intensity = E*(D/(D+L*r))*(Math.pow(D,2)/(Math.pow(D,2)+Q*Math.pow(r,2)));
-  
+
     if (light['@type'] === 'point')
     {
       type = 1;
@@ -261,7 +261,7 @@ export class SDFParser {
     let lightObj: THREE.Object3D = this.scene.createLight(type, diffuse, intensity, pose,
         distance, castShadows, name, direction, specular,
         attConst, attLin, attQuad, innerAngle, outerAngle, falloff);
-  
+
     return lightObj;
   }
 
@@ -282,7 +282,7 @@ export class SDFParser {
     let L = light.attenuation_linear;
     let Q = light.attenuation_quadratic;
     let intensity = E*(D/(D+L*r))*(Math.pow(D,2)/(Math.pow(D,2)+Q*Math.pow(r,2)));
-  
+
     let lightObj: THREE.Object3D = this.scene.createLight(
       // Protobuf light type starts at zero.
       light.type + 1,
@@ -300,7 +300,7 @@ export class SDFParser {
       light.spot_inner_angle,
       light.spot_outer_angle,
       light.spot_falloff);
-  
+
     return lightObj;
   }
 
@@ -315,13 +315,13 @@ export class SDFParser {
    * and orientation (THREE.Quaternion) properties
    */
   public parsePose(poseInput: string | object): Pose {
-    let pose: Pose = new Pose();  
+    let pose: Pose = new Pose();
 
     // Short circuit if poseInput is undefined
     if (poseInput === undefined) {
       return pose;
     }
-  
+
     if (poseInput.hasOwnProperty('position') &&
         poseInput.hasOwnProperty('orientation')) {
       pose.position.x = poseInput['position']['x'];
@@ -333,8 +333,8 @@ export class SDFParser {
       pose.orientation.w = poseInput['orientation']['w'];
       return pose;
     }
- 
-    let poseStr: string = ""; 
+
+    let poseStr: string = "";
     // Note: The pose might have an empty frame attribute. This is a valid XML
     // element though. In this case, the parser outputs
     // {@frame: "frame", #text: "pose value"}
@@ -344,9 +344,9 @@ export class SDFParser {
       }
       poseStr = poseInput['#text'];
     }
-  
+
     var values = poseStr.trim().split(/\s+/);
- 
+
     pose.position.x = parseFloat(values[0]);
     pose.position.y = parseFloat(values[1]);
     pose.position.z = parseFloat(values[2]);
@@ -356,7 +356,7 @@ export class SDFParser {
                                 parseFloat(values[4]),
                                 parseFloat(values[5]), 'ZYX');
     pose.orientation.setFromEuler(euler);
-  
+
     return pose;
   }
 
@@ -394,7 +394,7 @@ export class SDFParser {
     if (boolStr !== undefined) {
       return JSON.parse(boolStr);
     }
-  
+
     return false;
   }
 
@@ -411,27 +411,27 @@ export class SDFParser {
   public createMaterial(srcMaterial: any): Material {
     var texture, mat;
     let material: Material = new Material();
-  
+
     if (!srcMaterial) {
       return material;
     }
-  
+
     if (srcMaterial.ambient) {
       material.ambient = this.parseColor(srcMaterial.ambient);
     }
-  
+
     if (srcMaterial.diffuse) {
       material.diffuse = this.parseColor(srcMaterial.diffuse);
     }
-  
+
     if (srcMaterial.specular) {
       material.specular = this.parseColor(srcMaterial.specular);
     }
-  
+
     material.opacity = srcMaterial.opacity;
     material.normalMap = srcMaterial.normalMap;
     material.scale = srcMaterial.scale;
-  
+
     // normal map
     if (srcMaterial.normal_map)
     {
@@ -470,7 +470,7 @@ export class SDFParser {
         }
       }
     }
-  
+
     // Material properties received via a protobuf message are formatted
     // differently from SDF. This will map protobuf format onto sdf.
     if (srcMaterial.pbr) {
@@ -515,7 +515,7 @@ export class SDFParser {
         material.pbr.ambientOcclusionMap = srcMaterial.pbr.ambient_occlusion_map;
       }
     }
-  
+
     // Set the correct URLs of the PBR-related textures, if available.
     if (material.pbr && this.enablePBR) {
       // Iterator for the subsequent for loops. Used to avoid a linter warning.
@@ -524,11 +524,11 @@ export class SDFParser {
       if (material.pbr.albedoMap) {
         let albedoMap: string = '';
         let albedoMapName: string = material.pbr.albedoMap.split('/').pop()!;
-  
+
         if (material.pbr.albedoMap.startsWith('https://')) {
           this.addUrl(material.pbr.albedoMap);
         }
-  
+
         if (this.usingFilesUrls && this.customUrls.length !== 0) {
           for (let u = 0; u < this.customUrls.length; u++) {
             if (this.customUrls[u].indexOf(albedoMapName) > -1) {
@@ -545,16 +545,16 @@ export class SDFParser {
           }
         }
       }
-  
+
       if (material.pbr.emissiveMap) {
         let emissiveMap: string = '';
         let emissiveMapName: string =
           material.pbr.emissiveMap.split('/').pop()!;
-  
+
         if (material.pbr.emissiveMap.startsWith('https://')) {
           this.addUrl(material.pbr.emissiveMap);
         }
-  
+
         if (this.usingFilesUrls && this.customUrls.length !== 0) {
           for (u = 0; u < this.customUrls.length; u++) {
             if (this.customUrls[u].indexOf(emissiveMapName) > -1) {
@@ -571,15 +571,15 @@ export class SDFParser {
           }
         }
       }
-  
+
       if (material.pbr.normalMap) {
         let pbrNormalMap: string = '';
         let pbrNormalMapName: string = material.pbr.normalMap.split('/').pop()!;
-  
+
         if (material.pbr.normalMap.startsWith('https://')) {
           this.addUrl(material.pbr.normalMap);
         }
-  
+
         if (this.usingFilesUrls && this.customUrls.length !== 0) {
           for (u = 0; u < this.customUrls.length; u++) {
             if (this.customUrls[u].indexOf(pbrNormalMapName) > -1) {
@@ -596,15 +596,15 @@ export class SDFParser {
           }
         }
       }
-  
+
       if (material.pbr.roughnessMap) {
         let roughnessMap: string = '';
         let roughnessMapName: string = material.pbr.roughnessMap.split('/').pop()!;
-  
+
         if (material.pbr.roughnessMap.startsWith('https://')) {
           this.addUrl(material.pbr.roughnessMap);
         }
-  
+
         if (this.usingFilesUrls && this.customUrls.length !== 0) {
           for (u = 0; u < this.customUrls.length; u++) {
             if (this.customUrls[u].indexOf(roughnessMapName) > -1) {
@@ -621,16 +621,16 @@ export class SDFParser {
           }
         }
       }
-  
+
       if (material.pbr.metalnessMap) {
         let metalnessMap: string = '';
         let metalnessMapName: string =
           material.pbr.metalnessMap.split('/').pop()!;
-  
+
         if (material.pbr.metalnessMap.startsWith('https://')) {
           this.addUrl(material.pbr.metalnessMap);
         }
-  
+
         if (this.usingFilesUrls && this.customUrls.length !== 0) {
           for (u = 0; u < this.customUrls.length; u++) {
             if (this.customUrls[u].indexOf(metalnessMapName) > -1) {
@@ -648,7 +648,7 @@ export class SDFParser {
         }
       }
     }
-  
+
     return material;
   }
 
@@ -667,7 +667,7 @@ export class SDFParser {
         parseFloat(values[0]),
         parseFloat(values[1]),
         parseFloat(values[2]));
-    } 
+    }
 
     return new THREE.Vector3(sizeInput.x, sizeInput.y, sizeInput.z);
   }
@@ -695,9 +695,9 @@ export class SDFParser {
     let obj: THREE.Mesh | undefined = undefined;
     let size;
     let normal: THREE.Vector3 = new THREE.Vector3(0, 0, 1);
-  
+
     var material = this.createMaterial(mat);
-  
+
     if (geom.box)
     {
       if (geom.box.size) {
@@ -736,7 +736,7 @@ export class SDFParser {
       let submesh: string = '';
       let centerSubmesh: boolean = false;
       let modelName: string = '';
-  
+
       if (geom.mesh.submesh)
       {
         // Submesh information coming from protobuf messages is slightly
@@ -752,36 +752,36 @@ export class SDFParser {
           centerSubmesh = this.parseBool(geom.mesh.submesh.center);
         }
       }
-  
+
       var uriType = meshUri.substring(0, meshUri.indexOf('://'));
       if (uriType === 'file' || uriType === 'model') {
         modelName = meshUri.substring(meshUri.indexOf('://') + 3);
       } else {
         modelName = meshUri;
       }
-  
+
       if (geom.mesh.scale) {
         var scale = this.parseScale(geom.mesh.scale);
         parent.scale.x = scale.x;
         parent.scale.y = scale.y;
         parent.scale.z = scale.z;
       }
-  
+
       // Create a valid Fuel URI from the model name
       let modelUri: string = createFuelUri(modelName);
-  
+
       let ext: string = modelUri.substr(-4).toLowerCase();
       let materialName: string = parent.name + '::' + modelUri;
       this.entityMaterial[materialName] = material;
       let meshFileName: string = meshUri.substring(meshUri.lastIndexOf('/'));
-  
+
       if (!this.usingFilesUrls) {
         var meshFile = this.meshes[meshFileName];
         if (!meshFile) {
           console.error('Missing mesh file [' + meshFileName + ']');
           return;
         }
-  
+
         if (ext === '.obj') {
           var mtlFileName = meshFileName.split('.')[0]+'.mtl';
           var mtlFile = this.mtls[mtlFileName];
@@ -789,18 +789,18 @@ export class SDFParser {
             console.error('Missing MTL file [' + mtlFileName + ']');
             return;
           }
-  
+
           that.scene.loadMeshFromString(modelUri, submesh, centerSubmesh,
             function(obj: any): void {
               if (!obj) {
                 console.error('Failed to load mesh.');
                 return;
               }
-  
+
               parent.add(obj);
               loadGeom(parent);
-            }, 
-  
+            },
+
             // onError callback
             function(error: any): void {
               console.error(error);
@@ -814,7 +814,7 @@ export class SDFParser {
                 console.error('Failed to load mesh.');
                 return;
               }
-  
+
               if (material) {
                 let allChildren: THREE.Object3D[] = [];
                 getDescendants(dae, allChildren);
@@ -828,7 +828,7 @@ export class SDFParser {
               }
               parent.add(dae);
               loadGeom(parent);
-            }, 
+            },
             // onError callback
             function(error: any): void {
               console.error(error);
@@ -855,7 +855,7 @@ export class SDFParser {
             }
           }
         }
-  
+
         // Avoid loading the mesh multiple times.
         for (var i = 0; i < this.pendingMeshes.length; i++) {
           if (this.pendingMeshes[i].meshUri === modelUri) {
@@ -868,7 +868,7 @@ export class SDFParser {
               material: material,
               centerSubmesh: centerSubmesh
             });
-  
+
             // If the mesh exists, then create another version and add it to
             // the parent object.
             if (this.scene.meshes.has(modelUri)) {
@@ -890,7 +890,7 @@ export class SDFParser {
           material: material,
           centerSubmesh: centerSubmesh
         });
-  
+
         // Load the mesh.
         // Once the mesh is loaded, it will be stored on Gz3D.Scene.
         this.scene.loadMeshFromUri(modelUri, submesh, centerSubmesh,
@@ -900,7 +900,7 @@ export class SDFParser {
             // Check for the pending meshes.
             for (var i = 0; i < that.pendingMeshes.length; i++) {
               if (that.pendingMeshes[i].meshUri === mesh.name) {
-  
+
                 // No submesh: Load the result.
                 if (!that.pendingMeshes[i].submesh) {
                   loadMesh(mesh, that.pendingMeshes[i].material,
@@ -919,7 +919,7 @@ export class SDFParser {
                         // The new submesh will be parsed.
                         that.scene.loadMeshFromUri(mesh.name,
                           that.pendingMeshes[i].submesh,
-                          that.pendingMeshes[i].centerSubmesh, 
+                          that.pendingMeshes[i].centerSubmesh,
                           // on load
                           function(mesh: THREE.Mesh): void {
                             loadMesh(mesh, that.pendingMeshes[i].material,
@@ -967,7 +967,7 @@ export class SDFParser {
       parent.add(obj);
       loadGeom(parent);
     }
-  
+
     // Callback function when the mesh is ready.
     function loadMesh(mesh: THREE.Mesh, material: Material,
                       parent: THREE.Object3D, ext: string) {
@@ -975,7 +975,7 @@ export class SDFParser {
         console.error('Failed to load mesh.');
         return;
       }
-  
+
       // Note: This material is the one created by the createMaterial method,
       // which is the material defined by the SDF file or the material script.
       if (material) {
@@ -995,7 +995,7 @@ export class SDFParser {
               let isColladaWithTexture: boolean = ext === '.dae' &&
                 (<THREE.Mesh>allChildren[c]).material !== undefined &&
                 (<THREE.MeshBasicMaterial>(<THREE.Mesh>allChildren[c]).material).map !== undefined;
-  
+
               if (!isColladaWithTexture || material.pbr) {
                 that.scene.setMaterial(allChildren[c] as THREE.Mesh, material);
                 break;
@@ -1017,11 +1017,11 @@ export class SDFParser {
           that.scene.setMaterial(mesh, {'ambient': [1,1,1,1]});
         }
       }
-  
+
       parent.add(mesh.clone());
       loadGeom(parent);
     }
-  
+
     function loadGeom(visualObj: THREE.Object3D) {
       let allChildren: THREE.Object3D[] = [];
       getDescendants(visualObj, allChildren);
@@ -1031,7 +1031,7 @@ export class SDFParser {
         {
           allChildren[c].castShadow = true;
           allChildren[c].receiveShadow = true;
-  
+
           if (visualObj.castShadow)
           {
             allChildren[c].castShadow = visualObj.castShadow;
@@ -1040,12 +1040,12 @@ export class SDFParser {
           {
             allChildren[c].receiveShadow = visualObj.receiveShadow;
           }
-  
+
           if (visualObj.name.indexOf('COLLISION_VISUAL') >= 0)
           {
             allChildren[c].castShadow = false;
             allChildren[c].receiveShadow = false;
-  
+
             allChildren[c].visible = that.scene.showCollisions;
           }
           break;
@@ -1077,7 +1077,7 @@ export class SDFParser {
     if (visual.geometry)
     {
       visualObj.name = visual['@name'] || visual['name'];
- 
+
       if (visual.pose) {
         var visualPose = this.parsePose(visual.pose);
         this.scene.setPose(visualObj, visualPose.position,
@@ -1086,7 +1086,7 @@ export class SDFParser {
 
       this.createGeom(visual.geometry, visual.material, visualObj, options);
     }
-  
+
     return visualObj;
   }
 
@@ -1105,12 +1105,12 @@ export class SDFParser {
   public createSensor(sensor: any, options: any): THREE.Object3D {
     let sensorObj: THREE.Object3D = new THREE.Object3D();
     sensorObj.name = sensor['name'] || sensor['@name'] || '';
-  
+
     if (sensor.pose) {
       let sensorPose: Pose = this.parsePose(sensor.pose);
       this.scene.setPose(sensorObj, sensorPose.position, sensorPose.orientation);
     }
-  
+
     return sensorObj;
   }
 
@@ -1170,19 +1170,19 @@ export class SDFParser {
     } else {
       sdfXML = sdf;
     }
- 
-    var sdfObj; 
+
+    var sdfObj;
     // Convert SDF XML to Json string and parse JSON string to object
     // TODO: we need better xml 2 json object convertor
     /*Nate disabled var sdfJson = xml2json.toJson(sdfXML);
     var sdfObj = JSON.parse(sdfJson).sdf;
     // it is easier to manipulate json object
-  
+
     if (!sdfObj) {
       console.error('Failed to parse SDF: ', sdfJson);
       return;
     }*/
-  
+
     return sdfObj;
   }
 
@@ -1199,7 +1199,7 @@ export class SDFParser {
     }
     let lowerCaseName: string = sdfName.toLowerCase();
     let filename: string = '';
-  
+
     // In case it is a full URL
     if (lowerCaseName.indexOf('http') === 0) {
       filename = sdfName;
@@ -1212,12 +1212,12 @@ export class SDFParser {
         filename = this.MATERIAL_ROOT + '/' + sdfName + '/model.sdf';
       }
     }
-  
+
     if (!filename) {
       console.error('Error: unable to load ' + sdfName + ' - file not found');
       return;
     }
-  
+
     let that = this;
     this.fileFromUrl(filename, function(sdf: any) {
       if (!sdf) {
@@ -1245,26 +1245,26 @@ export class SDFParser {
     // create the model
     let modelObj: THREE.Object3D = new THREE.Object3D();
     modelObj.name = sdfObj.model['name'] || sdfObj.model['@name'];
- 
+
     let pose: Pose;
     let i, j, k: number;
     let visualObj: THREE.Object3D;
     let linkObj: THREE.Object3D;
     let linkPose: Pose;
-  
+
     if (sdfObj.model.pose)
     {
       pose = this.parsePose(sdfObj.model.pose);
       this.scene.setPose(modelObj, pose.position, pose.orientation);
     }
-  
+
     //convert link object to link array
     if (sdfObj.model.link) {
         if (!(sdfObj.model.link instanceof Array))
         {
           sdfObj.model.link = [sdfObj.model.link];
         }
-  
+
         for (i = 0; i < sdfObj.model.link.length; ++i)
         {
           linkObj = this.createLink(sdfObj.model.link[i], options);
@@ -1274,7 +1274,7 @@ export class SDFParser {
           }
         }
     }
-  
+
     //convert nested model objects to model array
     if (sdfObj.model.model)
     {
@@ -1292,20 +1292,20 @@ export class SDFParser {
         }
       }
     }
-  
+
     // Parse included models.
     if (sdfObj.model.include) {
       // Convert to array.
       if (!(sdfObj.model.include instanceof Array)) {
         sdfObj.model.include = [sdfObj.model.include];
       }
-  
+
       // Ignore linter warnings. We use arrow functions to avoid binding 'this'.
       sdfObj.model.include.forEach((includedModel: any) => {
         this.includeModel(includedModel, modelObj);
       });
     }
-  
+
     return modelObj;
   }
 
@@ -1325,7 +1325,7 @@ export class SDFParser {
   {
     var worldObj = new THREE.Object3D();
     worldObj.name = this.createUniqueName(sdfObj.world);
-  
+
     // remove default sun before adding objects
     // we will let the world file create its own light
     var sun = this.scene.getByName('sun');
@@ -1333,7 +1333,7 @@ export class SDFParser {
     {
       this.scene.remove(sun);
     }
-  
+
     // parse models
     if (sdfObj.world.model)
     {
@@ -1342,7 +1342,7 @@ export class SDFParser {
       {
         sdfObj.world.model = [sdfObj.world.model];
       }
-  
+
       for (var j = 0; j < sdfObj.world.model.length; ++j)
       {
         var tmpModelObj = {model: sdfObj.world.model[j]};
@@ -1350,7 +1350,7 @@ export class SDFParser {
         worldObj.add(modelObj);
       }
     }
-  
+
     // parse lights
     if (sdfObj.world.light)
     {
@@ -1359,7 +1359,7 @@ export class SDFParser {
       {
         sdfObj.world.light = [sdfObj.world.light];
       }
-  
+
       for (var k = 0; k < sdfObj.world.light.length; ++k)
       {
         var lightObj = this.spawnLight(sdfObj.world.light[k]);
@@ -1371,20 +1371,20 @@ export class SDFParser {
         }
       }
     }
-  
+
     // Parse included models.
     if (sdfObj.world.include) {
       // Convert to array.
       if (!(sdfObj.world.include instanceof Array)) {
         sdfObj.world.include = [sdfObj.world.include];
       }
-  
+
       // Ignore linter warnings. We use arrow functions to avoid binding 'this'.
       sdfObj.world.include.forEach((includedModel: any) => {
         this.includeModel(includedModel, worldObj);
       });
     }
-  
+
     return worldObj;
   }
 
@@ -1398,12 +1398,12 @@ export class SDFParser {
   public includeModel(includedModel: any, parent: THREE.Object3D): void {
     // Suppress linter warnings. This shouldn't be necessary after
     // switching to es6 or more.
-  
+
     // The included model is copied. This allows the SDF to be reused
     // without modifications. The parent is stored in the model, so we
     // don't lose their context once the model's Object3D is created.
     const model = {...includedModel, parent: parent};
-  
+
     // We need to request the files of the model to the Server.
     // In order to avoid duplicated requests, we store the model in an
     // array until their files are available.
@@ -1412,7 +1412,7 @@ export class SDFParser {
       // the Server. Add the model to the models array of the map, to use
       // them once the request resolves.
       this.pendingModels.set(model.uri, { models: [model] });
-  
+
       // Request the files from the server, and create the pending
       // models on it's callback.
       if (this.requestHeaderKey && this.requestHeaderValue) {
@@ -1429,7 +1429,7 @@ export class SDFParser {
           }
           this.addUrl(file);
         });
-  
+
         // Read and parse the SDF.
         this.fileFromUrl(sdfUrl, (sdf: any) => {
           if (!sdf) {
@@ -1438,13 +1438,13 @@ export class SDFParser {
             return;
           }
           const sdfObj = this.parseSDF(sdf);
-  
+
           const entry = this.pendingModels.get(model.uri);
           entry.sdf = sdfObj;
-  
+
           // Extract Fuel owner and name. Used to match the correct URL.
           let options: any;
-          if (model.uri.startsWith('https://') || 
+          if (model.uri.startsWith('https://') ||
               model.uri.startsWith('file://')) {
             const uriSplit = model.uri.split('/');
             const modelsIndex = uriSplit.indexOf('models');
@@ -1453,26 +1453,26 @@ export class SDFParser {
               fuelName: uriSplit[modelsIndex + 1],
             }
           }
-  
+
           entry.models.forEach((pendingModel: any) => {
             // Create the Object3D.
             const modelObj = this.spawnFromObj(sdfObj, options);
-  
+
             // Set name.
             if (pendingModel.name) {
               modelObj.name = pendingModel.name;
             }
-  
+
             // Set pose.
             if (pendingModel.pose) {
               const pose = this.parsePose(pendingModel.pose);
               this.scene.setPose(modelObj, pose.position, pose.orientation);
             }
-  
+
             // Add to parent.
             pendingModel.parent.add(modelObj);
           });
-  
+
           // Cleanup: Remove the list of models.
           entry.models = [];
         });
@@ -1481,7 +1481,7 @@ export class SDFParser {
       // The URI was received already. Push the model into the pending models array.
       const entry = this.pendingModels.get(model.uri);
       entry.models.push(model);
-  
+
       // If the SDF was already obtained, apply it to this model.
       if (entry.sdf) {
         // Extract Fuel owner and name. Used to match the correct URL.
@@ -1494,26 +1494,26 @@ export class SDFParser {
             fuelName: uriSplit[modelsIndex + 1],
           }
         }
-  
+
         entry.models.forEach((pendingModel: any) => {
           const sdfObj = entry.sdf;
           const modelObj = this.spawnFromObj(sdfObj, options);
-  
+
           // Set name.
           if (pendingModel.name) {
             modelObj.name = pendingModel.name;
           }
-  
+
           // Set pose.
           if (pendingModel.pose) {
             const pose = this.parsePose(pendingModel.pose);
             this.scene.setPose(modelObj, pose.position, pose.orientation);
           }
-  
+
           // Add to parent.
           pendingModel.parent.add(modelObj);
         });
-  
+
         // Cleanup: Remove the list of models.
         entry.models = [];
       }
@@ -1537,9 +1537,9 @@ export class SDFParser {
     let visualObj: THREE.Object3D;
     let sensorObj: THREE.Object3D;
     let linkObj: THREE.Object3D = new THREE.Object3D();
-  
+
     linkObj.name = link['name'] || link['@name'] || '';
- 
+
     if (link.inertial) {
       let inertialPose: Pose;
       let inertialMass: number
@@ -1561,17 +1561,17 @@ export class SDFParser {
         linkObj.userData.inertial.pose = inertialPose;
       }
     }
-  
+
     if (link.pose) {
       linkPose = this.parsePose(link.pose);
       this.scene.setPose(linkObj, linkPose.position, linkPose.orientation);
     }
-  
+
     if (link.visual) {
       if (!(link.visual instanceof Array)) {
         link.visual = [link.visual];
       }
-  
+
       for (var i = 0; i < link.visual.length; ++i) {
         visualObj = this.createVisual(link.visual[i], options);
         if (visualObj && !visualObj.parent) {
@@ -1579,12 +1579,12 @@ export class SDFParser {
         }
       }
     }
-  
+
     if (link.collision) {
       if (!(link.collision instanceof Array)) {
         link.collision = [link.collision];
       }
-  
+
       for (var j = 0; j < link.collision.length; ++j) {
         visualObj = this.createVisual(link.collision[j], options);
         if (visualObj && !visualObj.parent)
@@ -1596,7 +1596,7 @@ export class SDFParser {
         }
       }
     }
-  
+
     if (link.light) {
       if (!(link.light instanceof Array)) {
         link.light = [link.light];
@@ -1613,7 +1613,7 @@ export class SDFParser {
         }
       }
     }
-  
+
     if (link.particle_emitter) {
       if (!(link.particle_emitter instanceof Array)) {
         link.particle_emitter = [link.particle_emitter];
@@ -1628,12 +1628,12 @@ export class SDFParser {
         }
       }
     }
-  
+
     if (link.sensor) {
       if (!(link.sensor instanceof Array)) {
         link.sensor = [link.sensor];
       }
-  
+
       for (var sidx = 0; sidx < link.sensor.length; ++sidx) {
         sensorObj = this.createSensor(link.sensor[sidx], options);
         if (sensorObj && !sensorObj.parent) {
@@ -1641,7 +1641,7 @@ export class SDFParser {
         }
       }
     }
-  
+
     return linkObj;
   }
 
@@ -1654,7 +1654,7 @@ export class SDFParser {
   public createParticleEmitter(emitter: object): THREE.Object3D {
     // Particle Emitter is handled with ShaderParticleEngine, a third-party library.
     // More information at https://github.com/squarefeet/ShaderParticleEngine
-  
+
     // Auxliar function to extract the value of an emitter property from
     // either SDF or protobuf object (stored in a data property).
     function extractValue(property: any) {
@@ -1669,52 +1669,52 @@ export class SDFParser {
     }
     let particleEmitterObj = new THREE.Object3D();
     /* Nate disabled
-  
+
     // Given name of the emitter.
     let emitterName: string = this.createUniqueName(emitter);
-  
+
     // Whether the emitter is generating particles or not.
     let emitting: boolean = this.parseBool(extractValue('emitting')) || false;
-  
+
     // Duration of the particle emitter. Infinite if null.
     var duration = extractValue('duration');
     duration = duration !== undefined ? parseFloat(duration) : null;
-  
+
     // Emitter type.
     var type = extractValue('type') || extractValue('@type');
     type = type || 'point';
-  
+
     // Lifetime of the individual particles, in seconds.
     var lifetime = extractValue('lifetime');
     lifetime = lifetime !== undefined ? parseFloat(lifetime) : 5;
-  
+
     // Velocity range.
     var minVelocity = extractValue('min_velocity');
     minVelocity = minVelocity !== undefined ? parseFloat(minVelocity) : 1;
-  
+
     var maxVelocity = extractValue('max_velocity');
     maxVelocity = maxVelocity !== undefined ? parseFloat(maxVelocity) : 1;
-  
+
     // Size of the particle emitter.
     // The SDF particle emitter spec lists size as
     // [x: width, y: height, z: depth].
     var size = this.parse3DVector(emitter['size']) || new THREE.Vector3(1, 1, 1);
     size.set(size.z, size.x, size.y);
-  
+
     // Size of the individual particles.
     var particleSize = this.parse3DVector(emitter['particle_size']) || new THREE.Vector3(1, 1, 1);
-  
+
     // Pose of the particle emitter
     var pose = this.parsePose(emitter['pose']);
-  
+
     // Particles per second emitted.
     var rate = extractValue('rate');
     rate = rate !== undefined ? parseFloat(rate) : 10;
-  
+
     // Scale modifier for each particle. Modifies their size per second.
     var scaleRate = extractValue('scale_rate');
     scaleRate = scaleRate !== undefined ? parseFloat(scaleRate) : 1;
-  
+
     // Image that determines the color range. This image should be 1px in height.
     // NOTE: SPE can have up to four different values, and internally it
     // interpolates between these
@@ -1727,9 +1727,9 @@ export class SDFParser {
       colorRangeImage = colorRangeImage.data;
     }
     let colorRangeImageUrl: string = '';
-  
+
     var particleTexture;
-  
+
     // Texture image of the particles.
     if ('material' in emitter && 'pbr' in emitter['material']) {
       // SDF has a nested metal tag, while protobuf does not. Need to handle
@@ -1741,23 +1741,23 @@ export class SDFParser {
       }
     }
     let particleTextureUrl: string = '';
-  
+
     // Get the URL of the images used.
     if (this.usingFilesUrls) {
       for (var u = 0; u < this.customUrls.length; u++) {
         if (this.customUrls[u].indexOf(colorRangeImage) > -1) {
           colorRangeImageUrl = this.customUrls[u];
         }
-  
+
         if (this.customUrls[u].indexOf(particleTexture) > -1) {
           particleTextureUrl = this.customUrls[u];
         }
-  
+
         if (colorRangeImageUrl && particleTextureUrl) {
           break;
         }
       }
-  
+
       if (colorRangeImage && !colorRangeImageUrl) {
         colorRangeImageUrl = createFuelUri(colorRangeImage);
       }
@@ -1765,17 +1765,17 @@ export class SDFParser {
         particleTextureUrl = createFuelUri(particleTexture);
       }
     }
-  
+
     if (!colorRangeImageUrl) {
       console.error('color_range_image is missing, the particle emitter will not work');
       return particleEmitterObj ;
     }
-  
+
     if (!particleTextureUrl) {
       console.error('albedo_map is missing, the particle emitter will not work');
       return particleEmitterObj ;
     }
-  
+
     // Create the Particle Group.
     // This is the container for the Particle Emitter.
     // For more information, check http://squarefeet.github.io/ShaderParticleEngine/docs/api/SPE.Group.html
@@ -1791,60 +1791,60 @@ export class SDFParser {
       blending: THREE.NormalBlending,
     });
     particleGroup['name'] = emitterName;
-  
+
     // Particle Emitter.
     // For more information, check http://squarefeet.github.io/ShaderParticleEngine/docs/api/SPE.Emitter.html
     var particleEmitter = new SPE.Emitter({
       // How many particles this emitter will hold.
       // The rate of particles emitted per second is roughly the particleCount/lifetime.
       particleCount: rate * lifetime,
-  
+
       // Type of emitter. Box by default.
       // TODO(german) Support Point, Sphere and Cylinder (No direct relation with SPE)
       type: SPE.distributions.BOX,
-  
+
       // Duration of the particle emitter. Infinite if null.
       duration: duration > 0? duration : null,
-  
+
       // Position of the emitter. The value is the current position, and spread is related to the size.
       position: {
         value: new THREE.Vector3(0, 0, 0),
         spread: new THREE.Vector3().copy(size),
       },
-  
+
       // Particle velocity. Value is the base, and uses spread to randomize each particle.
       velocity: {
         value: new THREE.Vector3(minVelocity, 0, 0),
         spread: new THREE.Vector3(maxVelocity - minVelocity, 0, 0),
       },
-  
+
       // Particle size at the start and finish of their lifetime.
       // SPE interpolates these values.
       size: {
         value: [particleSize.x, particleSize.x + scaleRate * lifetime],
       },
-  
+
       // Lifetime of the individual particles, in seconds.
       maxAge: {
         value: lifetime
       },
     });
-  
+
     // The emitter is disabled until the the color and opacity information is read.
     particleEmitter.disable();
-  
+
     particleGroup.addEmitter(particleEmitter);
-  
-  
+
+
     // Create a new THREE.Object to hold the particle emitter. This allows us
     // to easily apply the particle emitter's position and orientation.
     console.log(pose.orientation);
     this.scene.setPose(particleEmitterObj, pose.position, pose.orientation);
     particleEmitterObj.add(particleGroup.mesh);
-  
+
     // This is required by the rendering loop.
     this.scene.addParticleGroup(particleGroup);
-  
+
     // Determine Color and Opacity information from the Color Range Image.
     // Note: SPE supports 4 values of opacity and color in an array. The engine automatically interpolates between them.
     // This means we cannot have all the colors from the image, instead, we pick only 4.
@@ -1853,14 +1853,14 @@ export class SDFParser {
       // A canvas is required to do so.
       const width: number = texture.image.width;
       const height: number = texture.image.height;
-  
+
       const canvas = document.createElement('canvas');
       canvas.width = width;
       canvas.height = height;
       const context = canvas.getContext('2d');
       context!.drawImage(texture.image, 0, 0);
       const imageData = context!.getImageData(0, 0, width, height)!;
-  
+
       const colorImgData = [];
       const opacityData = [];
       for (let i = 0; i < width; i += Math.floor(width/3)) {
@@ -1871,20 +1871,20 @@ export class SDFParser {
           imageData.data[i * 4 + 2] / 255
         )
         const opacity = imageData.data[i * 4 + 3] / 255;
-  
+
         colorImgData.push(color);
         opacityData.push(opacity);
       }
-  
+
       // Set the color and opacity of the particle emitter.
       for (let i = 0; i < 4; i++) {
         particleEmitter.color.value[i] = colorImgData[i];
         particleEmitter.color.value = particleEmitter.color.value;
-  
+
         particleEmitter.opacity.value[i] = opacityData[i];
         particleEmitter.opacity.value = particleEmitter.opacity.value;
       }
-  
+
       // Finally, enable the emission.
       if (emitting) {
         particleEmitter.enable();
@@ -1909,7 +1909,7 @@ export class SDFParser {
     let quaternion = new THREE.Quaternion();
     let modelObj: THREE.Object3D;
     let that = this;
-  
+
     if (model.matrixWorld) {
       let matrix: THREE.Matrix4 = model.matrixWorld;
       let scale: THREE.Vector3 = new THREE.Vector3();
@@ -1918,7 +1918,7 @@ export class SDFParser {
 
     let euler: THREE.Euler = new THREE.Euler();
     euler.setFromQuaternion(quaternion);
-  
+
     if (type === 'box') {
       sdf = this.createBoxSDF(translation, euler);
       modelObj = this.spawnFromSDF(sdf);
@@ -1945,7 +1945,7 @@ export class SDFParser {
         that.scene.setPose(modelObj, translation, quaternion);
       });
     }
-  
+
     let addModelFunc = function()
     {
       // check whether object is removed
@@ -1959,7 +1959,7 @@ export class SDFParser {
         setTimeout(addModelFunc, 100);
       }
     };
-  
+
     setTimeout(addModelFunc , 100);
   }
 
@@ -1977,7 +1977,7 @@ export class SDFParser {
   public createSimpleShapeSDF(type: string, translation: THREE.Vector3,
           euler: THREE.Euler, geomSDF: string): string {
     var sdf;
-  
+
     sdf = '<sdf version="' + this.SDF_VERSION + '">' + '<model name="' + type
             + '">' + '<pose>' + translation.x + ' ' + translation.y + ' '
             + translation.z + ' ' + euler.x + ' ' + euler.y + ' ' + euler.z
@@ -1989,7 +1989,7 @@ export class SDFParser {
             + '<uri>file://media/materials/scripts/gazebo.material' + '</uri>'
             + '<name>Gazebo/Grey</name>' + '</script>' + '</material>'
             + '</visual>' + '</link>' + '</model>' + '</sdf>';
-  
+
     return sdf;
   }
 
@@ -2002,7 +2002,7 @@ export class SDFParser {
    */
   public createBoxSDF(translation: THREE.Vector3, euler: THREE.Euler): string {
     var geomSDF = '<box>' + '<size>1.0 1.0 1.0</size>' + '</box>';
-  
+
     return this.createSimpleShapeSDF('box', translation, euler, geomSDF);
   }
 
@@ -2015,7 +2015,7 @@ export class SDFParser {
    */
   public createSphereSDF(translation: THREE.Vector3, euler: THREE.Euler): string {
     var geomSDF = '<sphere>' + '<radius>0.5</radius>' + '</sphere>';
-  
+
     return this.createSimpleShapeSDF('sphere', translation, euler, geomSDF);
   }
 
@@ -2029,7 +2029,7 @@ export class SDFParser {
   public createCylinderSDF(translation: THREE.Vector3, euler: THREE.Euler): string {
     var geomSDF = '<cylinder>' + '<radius>0.5</radius>' + '<length>1.0</length>'
             + '</cylinder>';
-  
+
     return this.createSimpleShapeSDF('cylinder', translation, euler, geomSDF);
   }
 
@@ -2057,11 +2057,11 @@ export class SDFParser {
     var xhttp = new XMLHttpRequest();
     xhttp.overrideMimeType('text/xml');
     xhttp.open('GET', url, true);
-  
+
     if (this.requestHeaderKey && this.requestHeaderValue) {
       xhttp.setRequestHeader(this.requestHeaderKey, this.requestHeaderValue);
     }
-  
+
     xhttp.onload = function() {
       if (xhttp.readyState === 4) {
         if (xhttp.status !== 200) {
@@ -2071,11 +2071,11 @@ export class SDFParser {
         callback(xhttp.responseXML);
       }
     };
-  
+
     xhttp.onerror = function (e) {
       console.error(xhttp.statusText);
     };
-  
+
     try {
       xhttp.send();
     } catch(err: any) {

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -3474,16 +3474,16 @@ export class Scene {
  /**
   * Print out the scene graph with position of each node.
   */
- public printScene() {
-   function printGraph(obj: THREE.Object3D): void {
-     console.group( ' <' + obj.type + '> ' + obj.name + ' pos: ' +
-                   obj.position.x + ', ' + obj.position.y + ', ' +
-                   obj.position.z );
-     obj.children.forEach( printGraph );
-     console.groupEnd();
-   }
-   printGraph(this.scene);
- }
+  public printScene(): void {
+    const printGraph = (obj: THREE.Object3D): void => {
+      console.group(
+        `<${obj.type}> ${obj.name} pos: ${obj.position.x}, ${obj.position.y}, ${obj.position.z}`
+      );
+      obj.children.forEach(printGraph);
+      console.groupEnd();
+    }
+    printGraph(this.scene);
+  }
 
  public loadTexture(url: string, onLoad?: any, onProgress?:any): THREE.Texture {
    let scope = this;

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -1443,25 +1443,25 @@ export class Scene {
 
     // unfortunately large heightmaps kill the fps and freeze everything so
     // we have to scale it down
-    var scale = 1;
-    var maxHeightmapWidth = 256;
-    var maxHeightmapHeight = 256;
+    let scale = 1;
+    const maxHeightmapWidth = 256;
+    const maxHeightmapHeight = 256;
 
-    if ((segmentWidth-1) > maxHeightmapWidth) {
-      scale = maxHeightmapWidth / (segmentWidth-1);
+    if ((segmentWidth - 1) > maxHeightmapWidth) {
+      scale = maxHeightmapWidth / (segmentWidth - 1);
     }
 
     let geometry: THREE.PlaneGeometry = new THREE.PlaneGeometry(width, height,
-        (segmentWidth-1) * scale, (segmentHeight-1) * scale);
+      (segmentWidth - 1) * scale, (segmentHeight - 1) * scale);
 
     let posAttribute = geometry.getAttribute('position');
 
     // Sub-sample
-    let col: number = (segmentWidth-1) * scale;
-    let row: number = (segmentHeight-1) * scale;
+    let col: number = (segmentWidth - 1) * scale;
+    let row: number = (segmentHeight - 1) * scale;
     for (let r = 0; r < row; ++r) {
       for (let c = 0; c < col; ++c) {
-        let index: number = (r * col * 1/(scale*scale)) +   (c * (1/scale));
+        let index: number = (r * col * 1/(scale*scale)) + (c * (1/scale));
         posAttribute.setZ(r*col + c, heights[index]);
       }
     }
@@ -1477,7 +1477,7 @@ export class Scene {
     if (textures && textures.length > 0) {
       let textureLoaded = [];
       let repeats = [];
-      for (var t = 0; t < textures.length; ++t) {
+      for (let t = 0; t < textures.length; ++t) {
         const texUri = createFuelUri(textures[t].diffuse);
         textureLoaded[t] = this.loadTexture(texUri);
         textureLoaded[t].wrapS = THREE.RepeatWrapping;
@@ -1501,11 +1501,11 @@ export class Scene {
 
       // Use the same approach as gazebo scene, grab the first directional light
       // and use it for shading the terrain
-      var lightDir = new THREE.Vector3(0, 0, -1);
-      var lightDiffuse = new THREE.Color(0xffffff);
+      let lightDir = new THREE.Vector3(0, 0, -1);
+      let lightDiffuse = new THREE.Color(0xffffff);
       let allObjects: THREE.Object3D[] = [];
       getDescendants(this.scene, allObjects);
-      for (var l = 0; l < allObjects.length; ++l) {
+      for (let l = 0; l < allObjects.length; ++l) {
         if (allObjects[l] instanceof THREE.DirectionalLight) {
           lightDir = (<THREE.DirectionalLight>allObjects[l]).target.position;
           lightDiffuse = (<THREE.DirectionalLight>allObjects[l]).color;
@@ -1513,7 +1513,7 @@ export class Scene {
         }
       }
 
-      var options = {
+      const options = {
         uniforms: {
           texture0: { type: 't', value: textureLoaded[0]},
           texture1: { type: 't', value: textureLoaded[1]},
@@ -1521,10 +1521,10 @@ export class Scene {
           repeat0: { type: 'f', value: repeats[0]},
           repeat1: { type: 'f', value: repeats[1]},
           repeat2: { type: 'f', value: repeats[2]},
-          minHeight1: { type: 'f', value: blends[0].min_height},
-          fadeDist1: { type: 'f', value: blends[0].fade_dist},
-          minHeight2: { type: 'f', value: blends[1].min_height},
-          fadeDist2: { type: 'f', value: blends[1].fade_dist},
+          minHeight1: { type: 'f', value: blends[0]?.min_height || 0},
+          fadeDist1: { type: 'f', value: blends[0]?.fade_dist || 0},
+          minHeight2: { type: 'f', value: blends[1]?.min_height || 0},
+          fadeDist2: { type: 'f', value: blends[1]?.fade_dist || 0},
           ambient: { type: 'c', value: this.ambient.color},
           lightDiffuse: { type: 'c', value: lightDiffuse},
           lightDir: { type: 'v3', value: lightDir}
@@ -1545,7 +1545,7 @@ export class Scene {
       material = new THREE.MeshPhongMaterial( { color: 0x555555 } );
     }
 
-    var mesh = new THREE.Mesh(geometry, material);
+    const mesh = new THREE.Mesh(geometry, material);
 
     mesh.position.x = origin.x;
     mesh.position.y = origin.y;

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -1,4 +1,4 @@
-import * as THREE from 'three'; 
+import * as THREE from 'three';
 // Nate disabled import * as SPE from '../include/SPE';
 import { getDescendants } from './Globals';
 import { ColladaLoader } from '../include/ColladaLoader';
@@ -250,15 +250,15 @@ export class Scene {
     this.name = 'default';
     this.scene = new THREE.Scene();
     // this.scene.name = this.name;
-  
+
     // only support one heightmap for now.
     this.heightmap = null;
-  
+
     this.selectedEntity = null;
-  
+
     this.manipulationMode = 'view';
     this.pointerOnMenu = false;
-  
+
     // loaders
     this.textureLoader = new THREE.TextureLoader();
     this.textureLoader.crossOrigin = '';
@@ -267,7 +267,7 @@ export class Scene {
       this.colladaLoader.findResourceCb = this.findResourceCb;
     }
     this.stlLoader = new STLLoader();
-  
+
     // Progress and Load events.
     /* jshint ignore:start */
     const progress = (url:string , items: any, total: number) => {
@@ -276,7 +276,7 @@ export class Scene {
     this.textureLoader.manager.onProgress = progress;
     this.colladaLoader.manager.onProgress = progress;
     this.stlLoader.manager.onProgress = progress;
-  
+
     const load = () => {
       this.emitter.emit('load_finished');
     }
@@ -284,7 +284,7 @@ export class Scene {
     this.colladaLoader.manager.onLoad = load;
     this.stlLoader.manager.onLoad = load;
     /* jshint ignore:end */
-  
+
     this.renderer = new THREE.WebGLRenderer({antialias: true});
     this.renderer.setPixelRatio(window.devicePixelRatio);
     this.renderer.setClearColor(this.backgroundColor);
@@ -292,21 +292,21 @@ export class Scene {
     this.renderer.shadowMap.enabled = true;
     this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
     // Particle group to render.
-  
+
     // Add a default ambient value. This is equivalent to
     // {r: 0.1, g: 0.1, b: 0.1}.
     this.ambient = new THREE.AmbientLight( 0x191919 );
     this.scene.add(this.ambient);
-  
+
     // camera
     let width: number = this.getDomElement().width;
     let height: number = this.getDomElement().height;
     this.camera = new THREE.PerspectiveCamera(60, width / height, 0.01, 1000);
     this.resetView();
-  
+
     // Clock used to time the camera 'move_to' motion.
     this.cameraMoveToClock = new THREE.Clock(false);
-  
+
     // Start position of the camera's move_to
     this.cameraLerpStart = new THREE.Vector3();
     // End position of the camera's move_to
@@ -315,10 +315,10 @@ export class Scene {
     this.cameraSlerpStart = new THREE.Quaternion();
     // End orientation of the camera's move_to
     this.cameraSlerpEnd = new THREE.Quaternion();
-  
+
     // Current camera mode. Empty indicates standard orbit camera.
     this.cameraMode = '';
-  
+
     // Ortho camera and scene for rendering sprites
     // Currently only used for the radial menu
     /*if (typeof RadialMenu === 'function')
@@ -327,12 +327,12 @@ export class Scene {
           height*0.5, -height*0.5, 1, 10);
       this.cameraOrtho.position.z = 10;
       this.sceneOrtho = new THREE.Scene();
-  
+
       // Radial menu (only triggered by touch)
       // this.radialMenu = new RadialMenu(this.getDomElement());
       // this.sceneOrtho.add(this.radialMenu.menu);
     }*/
-  
+
     // Grid
     this.grid = new THREE.GridHelper(20, 20, 0xCCCCCC, 0x4D4D4D);
     this.grid.name = 'grid';
@@ -343,42 +343,42 @@ export class Scene {
     (<THREE.Material>this.grid.material).opacity = 0.5;
     this.grid.visible = false;
     this.scene.add(this.grid);
-  
+
     this.showCollisions = false;
-  
+
     this.spawnModel = new SpawnModel(this, this.getDomElement());
-  
+
     this.simpleShapesMaterial = new THREE.MeshPhongMaterial(
         {color:0xffffff, flatShading: false} );
-  
+
     var that = this;
-  
+
     // Only capture events inside the webgl div element.
     this.getDomElement().addEventListener( 'mouseup',
         function(event: MouseEvent) {that.onPointerUp(event);}, false );
-  
+
     this.getDomElement().addEventListener( 'mousedown',
         function(event: MouseEvent) {that.onPointerDown(event);}, false );
-  
+
     this.getDomElement().addEventListener( 'wheel',
         function(event: MouseEvent) {that.onMouseScroll(event);}, false );
-  
+
     /*this.getDomElement().addEventListener( 'touchstart',
         function(event: TouchEvent) {that.onPointerDown(event);}, false );
-  
+
     this.getDomElement().addEventListener( 'touchend',
         function(event: TouchEvent) {that.onPointerUp(event);}, false );
        */
-  
+
     // Handles for translating and rotating objects
     //this.modelManipulator = new Manipulator(this.camera, false,
     //    this.getDomElement());
-  
+
     // this.timeDown = null;
-  
+
     // Create a ray caster
     this.ray = new THREE.Raycaster();
-  
+
     this.controls = new OrbitControls(this.camera,
         this.getDomElement());
     this.controls.mouseButtons = {
@@ -389,7 +389,7 @@ export class Scene {
     // an animation loop is required with damping
     this.controls.enableDamping = false;
     this.controls.screenSpacePanning = true;
-  
+
     // Bounding Box
     var indices = new Uint16Array(
         [ 0, 1, 1, 2, 2, 3, 3, 0,
@@ -402,112 +402,112 @@ export class Scene {
         new THREE.BufferAttribute(positions, 3));
     this.boundingBox = new THREE.LineSegments(boxGeometry,
         new THREE.LineBasicMaterial({color: 0xffffff}));
-  
+
     this.boundingBox.visible = false;
-  
+
     // Joint visuals
     this.jointAxis = new THREE.Object3D();
     this.jointAxis.name = 'JOINT_VISUAL';
     var geometry, material, mesh;
-  
+
     // XYZ
     var XYZaxes = new THREE.Object3D();
-  
+
     geometry = new THREE.CylinderGeometry(0.01, 0.01, 0.3, 10, 1, false);
-  
+
     material = new THREE.MeshBasicMaterial({color: new THREE.Color(0xff0000)});
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.x = 0.15;
     mesh.rotation.z = -Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     XYZaxes.add(mesh);
-  
+
     material = new THREE.MeshBasicMaterial({color: new THREE.Color(0x00ff00)});
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.y = 0.15;
     mesh.name = 'JOINT_VISUAL';
     XYZaxes.add(mesh);
-  
+
     material = new THREE.MeshBasicMaterial({color: new THREE.Color(0x0000ff)});
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.z = 0.15;
     mesh.rotation.x = Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     XYZaxes.add(mesh);
-  
+
     geometry = new THREE.CylinderGeometry(0, 0.03, 0.1, 10, 1, true);
-  
+
     material = new THREE.MeshBasicMaterial({color: new THREE.Color(0xff0000)});
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.x = 0.3;
     mesh.rotation.z = -Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     XYZaxes.add(mesh);
-  
+
     material = new THREE.MeshBasicMaterial({color: new THREE.Color(0x00ff00)});
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.y = 0.3;
     mesh.name = 'JOINT_VISUAL';
     XYZaxes.add(mesh);
-  
+
     material = new THREE.MeshBasicMaterial({color: new THREE.Color(0x0000ff)});
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.z = 0.3;
     mesh.rotation.x = Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     XYZaxes.add(mesh);
-  
+
     this.jointAxis['XYZaxes'] = XYZaxes;
-  
+
     var mainAxis = new THREE.Object3D();
-  
+
     material = new THREE.MeshLambertMaterial();
     material.color = new THREE.Color(0xffff00);
-  
+
     var mainAxisLen = 0.3;
     geometry = new THREE.CylinderGeometry(0.015, 0.015, mainAxisLen, 36, 1,
         false);
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.z = mainAxisLen * 0.5;
     mesh.rotation.x = Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     mainAxis.add(mesh);
-  
+
     geometry = new THREE.CylinderGeometry(0, 0.035, 0.1, 36, 1, false);
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.z = mainAxisLen;
     mesh.rotation.x = Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     mainAxis.add(mesh);
-  
+
     this.jointAxis['mainAxis'] = mainAxis;
-  
+
     var rotAxis = new THREE.Object3D();
-  
+
     geometry = new THREE.TorusGeometry(0.04, 0.006, 10, 36, Math.PI * 3/2);
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.z = mainAxisLen;
     mesh.name = 'JOINT_VISUAL';
     rotAxis.add(mesh);
-  
+
     geometry = new THREE.CylinderGeometry(0.015, 0, 0.025, 10, 1, false);
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.y = -0.04;
     mesh.position.z = mainAxisLen;
     mesh.rotation.z = Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     rotAxis.add(mesh);
-  
+
     this.jointAxis['rotAxis'] = rotAxis;
-  
+
     var transAxis = new THREE.Object3D();
-  
+
     geometry = new THREE.CylinderGeometry(0.01, 0.01, 0.1, 10, 1, true);
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.x = 0.03;
     mesh.position.y = 0.03;
@@ -515,9 +515,9 @@ export class Scene {
     mesh.rotation.x = Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     transAxis.add(mesh);
-  
+
     geometry = new THREE.CylinderGeometry(0.02, 0, 0.0375, 10, 1, false);
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.x = 0.03;
     mesh.position.y = 0.03;
@@ -525,7 +525,7 @@ export class Scene {
     mesh.rotation.x = -Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     transAxis.add(mesh);
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.x = 0.03;
     mesh.position.y = 0.03;
@@ -533,11 +533,11 @@ export class Scene {
     mesh.rotation.x = Math.PI/2;
     mesh.name = 'JOINT_VISUAL';
     transAxis.add(mesh);
-  
+
     this.jointAxis['transAxis'] = transAxis;
-  
+
     var screwAxis = new THREE.Object3D();
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.x = -0.04;
     mesh.position.z = mainAxisLen - 0.11;
@@ -545,7 +545,7 @@ export class Scene {
     mesh.rotation.x = -Math.PI/10;
     mesh.name = 'JOINT_VISUAL';
     screwAxis.add(mesh);
-  
+
     var radius = 0.04;
     var length = 0.02;
     var curve = new THREE.CatmullRomCurve3(
@@ -557,32 +557,32 @@ export class Scene {
         new THREE.Vector3(0, radius, 5*length),
         new THREE.Vector3(-radius, 0, 6*length)]);
     geometry = new THREE.TubeGeometry(curve, 36, 0.01, 10, false);
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.z = mainAxisLen - 0.23;
     mesh.name = 'JOINT_VISUAL';
     screwAxis.add(mesh);
-  
+
     this.jointAxis['screwAxis'] = screwAxis;
-  
+
     var ballVisual = new THREE.Object3D();
-  
+
     geometry = new THREE.SphereGeometry(0.06);
-  
+
     mesh = new THREE.Mesh(geometry, material);
     mesh.name = 'JOINT_VISUAL';
     ballVisual.add(mesh);
-  
+
     this.jointAxis['ballVisual'] = ballVisual;
-  
+
     // center of mass visual
     this.COMvisual = new THREE.Object3D();
     this.COMvisual.name = 'COM_VISUAL';
-  
+
     geometry = new THREE.SphereGeometry(1, 32, 32);
-  
+
     mesh = new THREE.Mesh(geometry);
-  
+
     // \todo: This should be fixed to point to a correct material.
     /*this.setMaterial(mesh, {'ambient':[0.5,0.5,0.5,1.000000],
       'texture':'assets/media/materials/textures/com.png'});
@@ -602,7 +602,7 @@ export class Scene {
       'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-negz.jpg',
       'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-posz.jpg',
     ]);
-  
+
     this.scene.background = cubeTexture;
   }
 
@@ -620,12 +620,12 @@ export class Scene {
    */
   public onPointerDown(event: MouseEvent): void {
     event.preventDefault();
- 
+
     if (this.spawnModel.active)
     {
       return;
     }
-  
+
     var mainPointer = true;
     let pos: THREE.Vector2;
     /*if (event.touches)
@@ -655,21 +655,21 @@ export class Scene {
         mainPointer = false;
       }
     //}
-  
+
     var intersect = new THREE.Vector3();
     var model = this.getRayCastModel(pos, intersect);
-  
+
     if (intersect)
     {
       this.controls.target = intersect;
     }
-  
+
     // Cancel in case of multitouch
     /*if (event.touches && event.touches.length !== 1)
     {
       return;
     }*/
-  
+
     // Manipulation modes
     // Model found
     if (model)
@@ -716,7 +716,7 @@ export class Scene {
    */
   public onPointerUp(event: MouseEvent) {
     event.preventDefault();
-  
+
     // Clicks (<150ms) outside any models trigger view mode
     // var millisecs = new Date().getTime();
     /*if (millisecs - this.timeDown < 150)
@@ -738,12 +738,12 @@ export class Scene {
    */
   public onMouseScroll(event: MouseEvent): void {
     event.preventDefault();
-  
+
     const pos: THREE.Vector2 = new THREE.Vector2(event.clientX, event.clientY);
-  
+
     let intersect: THREE.Vector3 = new THREE.Vector3();
     let model: THREE.Object3D = this.getRayCastModel(pos, intersect);
-  
+
     if (intersect) {
       this.controls.target = intersect;
     }
@@ -761,15 +761,15 @@ export class Scene {
       {
         var pos = new THREE.Vector2(this.getDomElement().width/2.0,
             this.getDomElement().height/2.0);
-  
+
         var intersect = new THREE.Vector3();
         var model = this.getRayCastModel(pos, intersect);
-  
+
         if (intersect)
         {
           this.controls.target = intersect;
         }
-  
+
         if (event.keyCode === 187)
         {
           this.controls.dollyOut();
@@ -780,7 +780,7 @@ export class Scene {
         }
       }
     }
-  
+
     // DEL to delete entities
     if (event.keyCode === 46)
     {
@@ -789,13 +789,13 @@ export class Scene {
         this.emitter.emit('delete_entity');
       }
     }
-  
+
     // F2 for turning on effects
     if (event.keyCode === 113)
     {
       // this.effectsEnabled = !this.effectsEnabled;
     }
-  
+
     // Esc/R/T for changing manipulation modes
     // TODO: Remove jquery from scene
     if (typeof Gui === 'function')
@@ -831,11 +831,11 @@ export class Scene {
       ((pos.x - rect.x) / rect.width) * 2 - 1,
       -((pos.y - rect.y) / rect.height) * 2 + 1);
     this.ray.setFromCamera(vector, this.camera);
-  
+
     let allObjects: THREE.Object3D[] = [];
     getDescendants(this.scene, allObjects);
     let objects: any [] = this.ray.intersectObjects(allObjects);
-  
+
     let model: THREE.Object3D = new THREE.Object3D();
     var point;
     if (objects.length > 0)
@@ -848,7 +848,7 @@ export class Scene {
           model = model.parent!;
           break;
         }
-  
+
         /*if (!this.modelManipulator.hovered &&
             (model.name === 'plane'))
         {
@@ -856,7 +856,7 @@ export class Scene {
           point = objects[i].point;
           break;
         }*/
-  
+
         if (model.name === 'grid' || model.name === 'boundingBox' ||
             model.name === 'JOINT_VISUAL' || model.name === 'INERTIA_VISUAL'
           || model.name === 'COM_VISUAL')
@@ -864,7 +864,7 @@ export class Scene {
           point = objects[i].point;
           continue;
         }
-  
+
         while (model.parent !== this.scene)
         {
           // Select current mode's handle
@@ -878,16 +878,16 @@ export class Scene {
           }*/
           model = model.parent!;
         }
-  
+
         /*if (this.radialMenu && model === this.radialMenu.menu)
         {
           continue;
         }*/
-  
+
         if (model.name.indexOf('COLLISION_VISUAL') >= 0) {
           continue;
         }
-  
+
         /*if (this.modelManipulator.hovered)
         {
           if (model === this.modelManipulator.gizmo)
@@ -942,7 +942,7 @@ export class Scene {
       this.controls.enabled = true;
     }*/
     this.controls.update();
-  
+
     // If 'follow' mode, then track the specifiec object.
     if (this.cameraMode === this.followEntityEvent) {
       // Using a hard-coded offset for now.
@@ -950,15 +950,15 @@ export class Scene {
       this.cameraTrackObject.updateMatrixWorld();
       var cameraOffset = relativeCameraOffset.applyMatrix4(
         this.cameraTrackObject.matrixWorld);
-  
+
       this.camera.position.lerp(cameraOffset, 0.1);
       this.camera.lookAt(this.cameraTrackObject.position);
-  
+
     } else if (this.cameraMode === this.moveToEntityEvent) {
       // Move the camera if "lerping" to an object.
       // Compute the lerp factor.
       var lerp = this.cameraMoveToClock.getElapsedTime() / 2.0;
-  
+
       // Stop the clock if the camera has reached it's target
       //if (Math.abs(1.0 - lerp) <= 0.005) {
       if (lerp >= 1.0) {
@@ -968,26 +968,26 @@ export class Scene {
         // Move the camera's position.
         this.camera.position.lerpVectors(this.cameraLerpStart, this.cameraLerpEnd,
           lerp);
-  
+
         // Move the camera's orientation.
         THREE.Quaternion.slerp(this.cameraSlerpStart, this.cameraSlerpEnd, this.camera.quaternion, lerp);
       }
     }
-  
+
     // this.modelManipulator.update();
     /*if (this.radialMenu)
     {
       this.radialMenu.update();
     }*/
-  
+
     /* Nate disabled if (this.particleGroup) {
       var clock = new THREE.Clock();
       this.particleGroup.tick( clock.getDelta() );
     }*/
-  
+
     this.renderer.clear();
     this.renderer.render(this.scene, this.camera);
-  
+
     this.renderer.clearDepth();
     if (this.sceneOrtho && this.cameraOrtho)
     {
@@ -1003,7 +1003,7 @@ export class Scene {
   public setSize(width: number, height: number): void {
     this.camera.aspect = width / height;
     this.camera.updateProjectionMatrix();
-  
+
     if (this.cameraOrtho)
     {
       this.cameraOrtho.left = -width / 2;
@@ -1012,7 +1012,7 @@ export class Scene {
       this.cameraOrtho.bottom = -height / 2;
       this.cameraOrtho.updateProjectionMatrix();
     }
-  
+
     this.renderer.setSize(width, height);
     this.render();
   }
@@ -1069,7 +1069,7 @@ export class Scene {
     {
       return;
     }*/
-  
+
     this.setPose(model, position, orientation);
   }
 
@@ -1168,7 +1168,7 @@ export class Scene {
   public createBox(width: number, height: number, depth: number): THREE.Mesh {
     let geometry: THREE.BoxGeometry =
       new THREE.BoxGeometry(width, height, depth, 1, 1, 1);
-  
+
     // Fix UVs so textures are mapped in a way that is consistent to gazebo
     // Some face uvs need to be rotated clockwise, while others anticlockwise
     // After updating to threejs rev 62, geometries changed from quads (6 faces)
@@ -1188,7 +1188,7 @@ export class Scene {
         geometry.faceVertexUvs[0][idx][0] = geometry.faceVertexUvs[0][idx][1];
         geometry.faceVertexUvs[0][idx][1] = geometry.faceVertexUvs[0][idx+1][1];
         geometry.faceVertexUvs[0][idx][2] = uva;
-  
+
         geometry.faceVertexUvs[0][idx+1][0] = geometry.faceVertexUvs[0][idx+1][1];
         geometry.faceVertexUvs[0][idx+1][1] = geometry.faceVertexUvs[0][idx+1][2];
         geometry.faceVertexUvs[0][idx+1][2] = geometry.faceVertexUvs[0][idx][2];
@@ -1197,7 +1197,7 @@ export class Scene {
     for (var ii = 0; ii < faceUVFixB.length; ++ii)
     {
       var idxB = faceUVFixB[ii]*2;
-  
+
       // Make sure that the index is valid. A threejs box geometry may not
       // have all of the faces if a dimension is sufficiently small.
       if (idxB+1 < geometry.faceVertexUvs.length) {
@@ -1205,7 +1205,7 @@ export class Scene {
         geometry.faceVertexUvs[0][idxB][0] = geometry.faceVertexUvs[0][idxB][2];
         geometry.faceVertexUvs[0][idxB][1] = uvc;
         geometry.faceVertexUvs[0][idxB][2] = geometry.faceVertexUvs[0][idxB+1][1];
-  
+
         geometry.faceVertexUvs[0][idxB+1][2] = geometry.faceVertexUvs[0][idxB][2];
         geometry.faceVertexUvs[0][idxB+1][1] = geometry.faceVertexUvs[0][idxB+1][0];
         geometry.faceVertexUvs[0][idxB+1][0] = geometry.faceVertexUvs[0][idxB][1];
@@ -1213,7 +1213,7 @@ export class Scene {
     }
    */
     uvAttribute.needsUpdate = true;
-  
+
     var mesh = new THREE.Mesh(geometry, this.simpleShapesMaterial);
     mesh.castShadow = true;
     return mesh;
@@ -1243,7 +1243,7 @@ export class Scene {
     inner_angle?: number, outer_angle?: number, falloff?: number): THREE.Object3D
   {
     let obj: THREE.Object3D = new THREE.Object3D();
-  
+
     if (typeof(diffuse) === 'undefined') {
       diffuse = new Color();
       diffuse.r = 1;
@@ -1251,14 +1251,14 @@ export class Scene {
       diffuse.b = 1;
       diffuse.a = 1;
     }
- 
+
     if (pose) {
       this.setPose(obj, pose.position, pose.orientation);
       obj.matrixWorldNeedsUpdate = true;
     }
-  
+
     let lightObj: THREE.Light;
- 
+
     if (type === 1) {
       lightObj = this.createPointLight(obj, diffuse, intensity,
           distance, cast_shadows);
@@ -1272,14 +1272,14 @@ export class Scene {
       console.error('Unknown light type', type);
       return obj;
     }
- 
+
     if (name) {
       lightObj.name = name;
       obj.name = name;
     }
- 
+
     obj.add(lightObj);
-  
+
     return obj;
   }
 
@@ -1298,16 +1298,16 @@ export class Scene {
     if (typeof(intensity) === 'undefined') {
       intensity = 0.5;
     }
-  
+
     var lightObj = new THREE.PointLight(color, intensity);
-  
+
     if (distance) {
       lightObj.distance = distance;
     }
     if (cast_shadows) {
       lightObj.castShadow = cast_shadows;
     }
-  
+
     return lightObj;
   }
 
@@ -1331,21 +1331,21 @@ export class Scene {
     if (typeof(distance) === 'undefined') {
       distance = 20;
     }
-  
+
     let lightObj: THREE.SpotLight =
       new THREE.SpotLight(color, intensity, distance);
     lightObj.position.set(0,0,0);
-  
+
     if (inner_angle !== null && outer_angle !== null) {
       lightObj.angle = outer_angle!;
       lightObj.penumbra = Math.max(1,
         (outer_angle! - inner_angle!) / ((inner_angle! + outer_angle!) / 2.0));
     }
-  
+
     if (falloff !== null) {
       lightObj.decay = falloff!;
     }
-  
+
     if (cast_shadows) {
       lightObj.castShadow = cast_shadows!;
     }
@@ -1359,11 +1359,11 @@ export class Scene {
     }
     let targetObj: THREE.Object3D = new THREE.Object3D();
     lightObj.add(targetObj);
-  
+
     targetObj.position.copy(dir);
     targetObj.matrixWorldNeedsUpdate = true;
     lightObj.target = targetObj;
- 
+
     return lightObj;
   }
 
@@ -1383,7 +1383,7 @@ export class Scene {
     if (typeof(intensity) === 'undefined') {
       intensity = 1;
     }
-  
+
     var lightObj = new THREE.DirectionalLight(color, intensity);
     lightObj.shadow.camera.near = 1;
     lightObj.shadow.camera.far = 50;
@@ -1394,7 +1394,7 @@ export class Scene {
     lightObj.shadow.camera.top = 100;
     lightObj.shadow.bias = 0.0001;
     lightObj.position.set(0,0,0);
-  
+
     if (cast_shadows) {
       lightObj.castShadow = cast_shadows;
     }
@@ -1408,11 +1408,11 @@ export class Scene {
     }
     let targetObj: THREE.Object3D = new THREE.Object3D();
     lightObj.add(targetObj);
-  
+
     targetObj.position.copy(dir);
     targetObj.matrixWorldNeedsUpdate = true;
     lightObj.target = targetObj;
-  
+
     return lightObj;
   }
 
@@ -1435,25 +1435,25 @@ export class Scene {
       console.error('Only one heightmap can be loaded at a time');
       return;
     }
-  
+
     if (parent === undefined) {
       console.error('Missing parent, heightmap won\'t be loaded.');
       return;
     }
-  
+
     // unfortunately large heightmaps kill the fps and freeze everything so
     // we have to scale it down
     var scale = 1;
     var maxHeightmapWidth = 256;
     var maxHeightmapHeight = 256;
-  
+
     if ((segmentWidth-1) > maxHeightmapWidth) {
       scale = maxHeightmapWidth / (segmentWidth-1);
     }
-  
+
     let geometry: THREE.PlaneGeometry = new THREE.PlaneGeometry(width, height,
         (segmentWidth-1) * scale, (segmentHeight-1) * scale);
-  
+
     let posAttribute = geometry.getAttribute('position');
 
     // Sub-sample
@@ -1466,11 +1466,11 @@ export class Scene {
       }
     }
     posAttribute.needsUpdate = true;
-  
+
     // Compute normals
     geometry.normalizeNormals();
     geometry.computeVertexNormals();
-  
+
     // Material - use shader if textures provided, otherwise use a generic phong
     // material
     let material;
@@ -1484,21 +1484,21 @@ export class Scene {
         textureLoaded[t].wrapT = THREE.RepeatWrapping;
         repeats[t] = width/textures[t].size;
       }
-  
+
       // for now, use fixed number of textures and blends
       // so populate the remaining ones to make the fragment shader happy
       for (let tt = textures.length; tt< 3; ++tt) {
         textureLoaded[tt] = textureLoaded[tt-1];
       }
-  
+
       for (let b = blends.length; b < 2; ++b) {
         blends[b] = blends[b-1];
       }
-  
+
       for (let rr = repeats.length; rr < 3; ++rr) {
         repeats[rr] = repeats[rr-1];
       }
-  
+
       // Use the same approach as gazebo scene, grab the first directional light
       // and use it for shading the terrain
       var lightDir = new THREE.Vector3(0, 0, -1);
@@ -1512,7 +1512,7 @@ export class Scene {
           break;
         }
       }
-  
+
       var options = {
         uniforms: {
           texture0: { type: 't', value: textureLoaded[0]},
@@ -1532,26 +1532,26 @@ export class Scene {
         vertexShader: '',
         fragmentShader: ''
       };
-  
+
       if (this.shaders !== undefined) {
         options.vertexShader = this.shaders.heightmapVS;
         options.fragmentShader = this.shaders.heightmapFS;
       } else {
         console.warn('Warning: heightmap shaders not provided.');
       }
-  
+
       material = new THREE.ShaderMaterial(options);
     } else {
       material = new THREE.MeshPhongMaterial( { color: 0x555555 } );
     }
-  
+
     var mesh = new THREE.Mesh(geometry, material);
-  
+
     mesh.position.x = origin.x;
     mesh.position.y = origin.y;
     mesh.position.z = origin.z;
     parent.add(mesh);
-  
+
     this.heightmap = parent;
   }
 
@@ -1575,7 +1575,7 @@ export class Scene {
     onLoad: any, onError: any): void {
     var uriPath = uri.substring(0, uri.lastIndexOf('/'));
     var uriFile = uri.substring(uri.lastIndexOf('/') + 1);
-  
+
     // Check if the mesh has already been loaded.
     // Use it in that case.
     if (this.meshes.has(uri))
@@ -1588,7 +1588,7 @@ export class Scene {
       }
       return;
     }
-  
+
     // load meshes
     if (uriFile.substr(-4).toLowerCase() === '.dae') {
       return this.loadCollada(uri, submesh, centerSubmesh, onLoad, onError);
@@ -1634,7 +1634,7 @@ export class Scene {
                             onError: any, files: string[]): void {
     var uriPath = uri.substring(0, uri.lastIndexOf('/'));
     var uriFile = uri.substring(uri.lastIndexOf('/') + 1);
-  
+
     if (this.meshes.has(uri))
     {
       let mesh: THREE.Mesh = this.meshes.get(uri)!.clone();
@@ -1645,7 +1645,7 @@ export class Scene {
       }
       return;
     }
-  
+
     // load mesh
     if (uriFile.substr(-4).toLowerCase() === '.dae')
     {
@@ -1685,7 +1685,7 @@ export class Scene {
     let dae: THREE.Mesh;
     var mesh = null;
     var that = this;
-  
+
     /*
     // Crashes: issue #36
     if (this.meshes.has(uri))
@@ -1704,7 +1704,7 @@ export class Scene {
         var scale = collada.dae.asset.unit;
         collada.scene.scale = new THREE.Vector3(scale, scale, scale);
       }*/
-  
+
       dae = collada.scene;
       dae.updateMatrix();
       that.prepareColladaMesh(dae);
@@ -1717,7 +1717,7 @@ export class Scene {
         onLoad(dae);
       }
     }
-  
+
     if (!filestring) {
       this.colladaLoader.load(uri,
         // onLoad callback
@@ -1771,13 +1771,13 @@ export class Scene {
     }
 
     let result: THREE.Mesh;
-  
+
     // The mesh has children for every submesh. Those children are either
     // meshes or groups that contain meshes. We need to modify the mesh, so
     // only the required submesh is contained in it. Note: If a submesh is
     // contained in a group, we need to preserve that group, as it may apply
     // matrix transformations required by the submesh.
-  
+
     // Auxiliary function used to look for the required submesh.
     // Checks if the given submesh is the one we look for. If it's a Group, look for it within its children.
     // It returns the submesh, if found.
@@ -1785,7 +1785,7 @@ export class Scene {
       if (obj instanceof THREE.Mesh &&
           obj.name === submesh && obj.hasOwnProperty('geometry')) {
         // Found the submesh.
-  
+
         // Center the submesh.
         if (centerSubmesh) {
           // obj file
@@ -1820,7 +1820,7 @@ export class Scene {
               geomPosition.setXYZ(i, newPos.x, newPos.y, newPos.z);
             }
             geomPosition.needsUpdate = true;
-  
+
             // Center the position.
             obj.position.set(0, 0, 0);
             var childParent = obj.parent;
@@ -1830,14 +1830,14 @@ export class Scene {
             }
           }
         }
-  
+
         // Filter the children of the parent. Only the required submesh
         // needs to be there.
         parent.children = [obj];
         return obj;
       } else if (obj instanceof THREE.Group) {
         for (let i: number = 0; i < obj.children.length; i++) {
-          if (obj.children[i] instanceof THREE.Mesh || 
+          if (obj.children[i] instanceof THREE.Mesh ||
               obj.children[i] instanceof THREE.Group) {
             let result = lookForSubmesh(obj.children[i] as any, obj);
             if (result) {
@@ -1854,10 +1854,10 @@ export class Scene {
 
       return obj;
     }
-  
+
     // Look for the submesh in the children of the mesh.
     for (var i = 0; i < mesh.children.length; i++) {
-      if (mesh.children[i] instanceof THREE.Mesh || 
+      if (mesh.children[i] instanceof THREE.Mesh ||
           mesh.children[i] instanceof THREE.Group) {
         let result = lookForSubmesh(mesh.children[i] as any, mesh);
         if (result) {
@@ -1865,7 +1865,7 @@ export class Scene {
         }
       }
     }
-  
+
     return null;
   }
 
@@ -1905,7 +1905,7 @@ export class Scene {
         mesh = new THREE.Mesh(geometry);
         mesh.castShadow = true;
         mesh.receiveShadow = true;
-  
+
         that.meshes.set(uri, mesh);
         mesh = mesh.clone();
         mesh.name = uri;
@@ -1938,15 +1938,15 @@ export class Scene {
   public setMaterial(obj: THREE.Mesh, material: any): void
   {
     var scope = this;
-  
 
-  
+
+
     if (obj)
     {
       if (material)
       {
 
-  
+
         // If the material has a PBR tag, use a MeshStandardMaterial,
         // which can have albedo, normal, emissive, roughness and metalness
         // maps. Otherwise use a Phong material.
@@ -1954,42 +1954,42 @@ export class Scene {
           obj.material = new THREE.MeshStandardMaterial();
           // Array of maps in order to facilitate the repetition and scaling process.
           var maps = [];
- 
+
           if (material.pbr.albedoMap) {
             let albedoMap = this.loadTexture(material.pbr.albedoMap);
             (obj.material as any).map = albedoMap;
             maps.push(albedoMap);
-  
+
             // enable alpha test for textures with alpha transparency
             if (albedoMap.format === THREE.RGBAFormat) {
               obj.material.alphaTest = 0.5;
             }
           }
-  
+
           if (material.pbr.normalMap) {
             let normalMap = this.loadTexture(material.pbr.normalMap);
             (obj.material as any).normalMap = normalMap;
             maps.push(normalMap);
           }
-  
+
           if (material.pbr.emissiveMap) {
             let emissiveMap = this.loadTexture(material.pbr.emissiveMap);
             (obj.material as any).emissiveMap = emissiveMap;
             maps.push(emissiveMap);
           }
-  
+
           if (material.pbr.roughnessMap) {
             let roughnessMap = this.loadTexture(material.pbr.roughnessMap);
             (obj.material as any).roughnessMap = roughnessMap;
             maps.push(roughnessMap);
           }
-  
+
           if (material.pbr.metalnessMap) {
             let metalnessMap = this.loadTexture(material.pbr.metalnessMap);
             (obj.material as any).metalnessMap = metalnessMap;
             maps.push(metalnessMap);
           }
-  
+
           maps.forEach(function(map) {
             map.wrapS = map.wrapT = THREE.RepeatWrapping;
             map.repeat.x = 1.0;
@@ -2001,12 +2001,12 @@ export class Scene {
           });
         } else {
           obj.material = new THREE.MeshPhongMaterial();
-  
+
           const specular = material.specular;
           if (specular) {
             (obj.material as any).specular.copy(specular);
           }
-  
+
           if (material.texture)
           {
             let texture = this.loadTexture(material.texture);
@@ -2018,19 +2018,19 @@ export class Scene {
               texture.repeat.y = 1.0 / material.scale[1];
             }
             (obj.material as any).map = texture;
-  
+
             // enable alpha test for textures with alpha transparency
             if (texture.format === THREE.RGBAFormat) {
               obj.material.alphaTest = 0.5;
             }
           }
-  
+
           if (material.normalMap) {
             (obj.material as any).normalMap =
               this.loadTexture(material.normalMap);
           }
         }
-  
+
         var ambient = material.ambient;
         var diffuse = material.diffuse;
         if (diffuse)
@@ -2070,7 +2070,7 @@ export class Scene {
    */
   public setManipulationMode(mode: string): void {
     this.manipulationMode = mode;
-  
+
     if (mode === 'view')
     {
       /*if (this.modelManipulator.object)
@@ -2107,7 +2107,7 @@ export class Scene {
     {
       return;
     }
-  
+
     let allObjects: THREE.Object3D[] = [];
     getDescendants(this.scene, allObjects);
     for (let i = 0; i < allObjects.length; ++i)
@@ -2139,7 +2139,7 @@ export class Scene {
     {
       this.emitter.emit('entityChanged', this.modelManipulator.object);
     }
-  
+
     if (mode !== 'view')
     {
       this.modelManipulator.attach(model);
@@ -2160,19 +2160,19 @@ export class Scene {
     if (entityName === undefined || entityName === null) {
       return;
     }
-  
+
     /* Helper function to enable all child lights */
     function enableLightsHelper(obj: any) {
       if (obj === null || obj === undefined) {
         return;
       }
-  
+
       if (obj.userData.hasOwnProperty('type') &&
           obj.userData.type === 'light') {
         obj.visible = !obj.visible;
       }
     }
-  
+
     // Find the object and set the lights.
     var object = this.scene.getObjectByName(entityName);
     if (object !== null && object !== undefined) {
@@ -2201,7 +2201,7 @@ export class Scene {
     // An explicit call to render is required. Otherwise the obtained image will be black.
     // See https://threejsfundamentals.org/threejs/lessons/threejs-tips.html, "Taking A Screenshot of the Canvas"
     this.render();
-  
+
     this.getDomElement().toBlob(function(blob: any) {
       let url = URL.createObjectURL(blob);
       let linkElement = document.createElement('a');
@@ -2232,25 +2232,25 @@ export class Scene {
         });
       });
     }
-  
+
     let zip: JSZip = new JSZip();
     const canvas = this.getDomElement();
     const promises = [];
-  
+
     // Directional light and target.
     const lightTarget = new THREE.Object3D();
     lightTarget.name = 'thumbnails_light_target';
     lightTarget.position.copy(center);
     this.scene.add(lightTarget);
-  
+
     const light = new THREE.DirectionalLight( 0xffffff, 1.0 );
     light.name = 'thumbnails_light';
     this.scene.add(light);
     light.target = lightTarget;
-  
+
     // Note: An explicit call to render is required for each image. Otherwise the obtained image will be black.
     // See https://threejsfundamentals.org/threejs/lessons/threejs-tips.html, "Taking A Screenshot of the Canvas"
-  
+
     // Perspective
     this.camera.position.copy(center);
     this.camera.position.add(new THREE.Vector3(1.6, -1.6, 1.2));
@@ -2262,7 +2262,7 @@ export class Scene {
       zip.file('thumbnails/1.png', <Blob>(blob));
     });
     promises.push(perspective);
-  
+
     // Top
     this.camera.position.copy(center);
     this.camera.position.add(new THREE.Vector3(0, 0, 2.2));
@@ -2274,7 +2274,7 @@ export class Scene {
       zip.file('thumbnails/2.png', <Blob>(blob));
     });
     promises.push(top);
-  
+
     // Front
     this.camera.position.copy(center);
     this.camera.position.add(new THREE.Vector3(2.2, 0, 0));
@@ -2286,7 +2286,7 @@ export class Scene {
       zip.file('thumbnails/3.png', <Blob>(blob));
     });
     promises.push(front);
-  
+
     // Side
     this.camera.position.copy(center);
     this.camera.position.add(new THREE.Vector3(0, 2.2, 0));
@@ -2298,7 +2298,7 @@ export class Scene {
       zip.file('thumbnails/4.png', <Blob>(blob));
     });
     promises.push(side);
-  
+
     // Back
     this.camera.position.copy(center);
     this.camera.position.add(new THREE.Vector3(-2.2, 0, 0));
@@ -2311,7 +2311,7 @@ export class Scene {
       zip.file('thumbnails/5.png', <Blob>(blob));
     });
     promises.push(back);
-  
+
     Promise.all(promises).then(() => {
       zip.generateAsync({type: 'blob'}).then(function(content: any) {
         const url = URL.createObjectURL(content);
@@ -2323,7 +2323,7 @@ export class Scene {
         document.body.removeChild(linkElement);
         URL.revokeObjectURL(url);
       });
-  
+
       this.scene.remove(light);
       this.scene.remove(lightTarget);
     });
@@ -2338,15 +2338,15 @@ export class Scene {
     {
       return;
     }
-  
+
     var event = e.originalEvent;
-  
+
     var pointer = event.touches ? event.touches[ 0 ] : event;
     var pos = new THREE.Vector2(pointer.clientX, pointer.clientY);
-  
+
     var intersect = new THREE.Vector3();
     var model = this.getRayCastModel(pos, intersect);
-  
+
     if (model && model.name !== '' && model.name !== 'plane'
         && this.modelManipulator.pickerNames.indexOf(model.name) === -1)
     {
@@ -2365,26 +2365,26 @@ export class Scene {
     box.max.x = box.max.y = box.max.z = - Infinity;
     var v = new THREE.Vector3();
     object.updateMatrixWorld( true );
-  
+
     object.traverse( function (node: THREE.Object3D) {
       let i, l;
       if (node instanceof THREE.Mesh)
       {
         let geometry = (node as THREE.Mesh).geometry;
-  
+
         if (node.name !== 'INERTIA_VISUAL' && node.name !== 'COM_VISUAL')
         {
           if (geometry.isBufferGeometry) {
             let attribute = geometry.getAttribute('position');
-  
+
             if (attribute !== undefined) {
               for (i = 0, l = attribute.count; i < l; i++) {
-  
+
                 v.fromBufferAttribute(attribute, i).applyMatrix4(
                   node.matrixWorld);
-  
+
                 expandByPoint(v);
-  
+
               }
             }
           } else {
@@ -2393,7 +2393,7 @@ export class Scene {
         }
       }
     });
-  
+
     function expandByPoint(point: THREE.Vector3) {
       box.min.min( point );
       box.max.max( point );
@@ -2408,7 +2408,7 @@ export class Scene {
     if (typeof model === 'string') {
       model = this.scene.getObjectByName(model)!;
     }
-  
+
     if (this.boundingBox.visible) {
       if (this.boundingBox.parent === model) {
         return;
@@ -2427,7 +2427,7 @@ export class Scene {
     box.max.x = box.max.x - model.position.x;
     box.max.y = box.max.y - model.position.y;
     box.max.z = box.max.z - model.position.z;
-  
+
     let position = this.boundingBox.geometry.getAttribute('position');
     //var array = position.array;
     position.setXYZ(0, box.max.x, box.max.y, box.max.z);
@@ -2440,7 +2440,7 @@ export class Scene {
     position.setXYZ(7, box.max.x, box.min.y, box.min.z);
     position.needsUpdate = true;
     this.boundingBox.geometry.computeBoundingSphere();
-  
+
     // rotate the box back to the world
     var modelRotation = new THREE.Matrix4();
     modelRotation.extractRotation(model.matrixWorld);
@@ -2449,7 +2449,7 @@ export class Scene {
     this.boundingBox.quaternion.setFromRotationMatrix(modelInverse);
     this.boundingBox.name = 'boundingBox';
     this.boundingBox.visible = true;
-  
+
     // Add box as model's child
     model.add(this.boundingBox);
   }
@@ -2473,7 +2473,7 @@ export class Scene {
   public onRightClick(event: any, callback: any): void {
     var pos = new THREE.Vector2(event.clientX, event.clientY);
     var model = this.getRayCastModel(pos, new THREE.Vector3());
-  
+
     if(model && model.name !== '' && model.name !== 'plane'/* &&
         this.modelManipulator.pickerNames.indexOf(model.name) === -1*/)
     {
@@ -2491,7 +2491,7 @@ export class Scene {
     if ((<ModelUserData>model.userData).viewAs === viewAs) {
       viewAs = 'normal';
     }
-  
+
     var showWireframe = (viewAs === 'wireframe');
     function materialViewAs(material: THREE.Material)
     {
@@ -2519,7 +2519,7 @@ export class Scene {
         (material as any).wireframe = showWireframe;
       }
     }
-  
+
     let wireframe;
     let descendants: THREE.Object3D[] = [];
     let materials: number[] = [];
@@ -2561,7 +2561,7 @@ export class Scene {
       if (parent.name.indexOf(name) !== -1) {
         return parent;
       }
-  
+
       parent = parent.parent;
     }
     return null;
@@ -2606,9 +2606,9 @@ export class Scene {
     {
       return;
     }
-  
+
     var child;
-  
+
     // Visuals already exist
     if (model.jointVisuals)
     {
@@ -2627,12 +2627,12 @@ export class Scene {
         for (var s = 0; s < model.joint.length; ++s)
         {
           child = model.getObjectByName(model.joint[s].child);
-  
+
           if (!child)
           {
             continue;
           }
-  
+
           child.add(model.jointVisuals[s]);
         }
       }
@@ -2644,21 +2644,21 @@ export class Scene {
       for (var j = 0; j < model.joint.length; ++j)
       {
         child = model.getObjectByName(model.joint[j].child);
-  
+
         if (!child)
         {
           continue;
         }
-  
+
         // XYZ expressed w.r.t. child
         var jointVisual = this.jointAxis['XYZaxes'].clone();
         child.add(jointVisual);
         model.jointVisuals.push(jointVisual);
         jointVisual.scale.set(0.7, 0.7, 0.7);
-  
+
         this.setPose(jointVisual, model.joint[j].pose.position,
             model.joint[j].pose.orientation);
-  
+
         var mainAxis = null;
         if (model.joint[j].type !== JointTypes.BALL &&
             model.joint[j].type !== JointTypes.FIXED)
@@ -2666,7 +2666,7 @@ export class Scene {
           mainAxis = this.jointAxis['mainAxis'].clone();
           jointVisual.add(mainAxis);
         }
-  
+
         var secondAxis = null;
         if (model.joint[j].type === JointTypes.REVOLUTE2 ||
             model.joint[j].type === JointTypes.UNIVERSAL)
@@ -2674,7 +2674,7 @@ export class Scene {
           secondAxis = this.jointAxis['mainAxis'].clone();
           jointVisual.add(secondAxis);
         }
-  
+
         if (model.joint[j].type === JointTypes.REVOLUTE ||
             model.joint[j].type === JointTypes.GEARBOX)
         {
@@ -2698,7 +2698,7 @@ export class Scene {
         {
           mainAxis.add(this.jointAxis['screwAxis'].clone());
         }
-  
+
         var direction, tempMatrix, rotMatrix;
         if (mainAxis)
         {
@@ -2712,13 +2712,13 @@ export class Scene {
           {
             model.joint[j].axis1.use_parent_model_frame = true;
           }
-  
+
           direction = new THREE.Vector3(
               model.joint[j].axis1.xyz.x,
               model.joint[j].axis1.xyz.y,
               model.joint[j].axis1.xyz.z);
           direction.normalize();
-  
+
           tempMatrix = new THREE.Matrix4();
           if (model.joint[j].axis1.use_parent_model_frame)
           {
@@ -2729,25 +2729,25 @@ export class Scene {
             tempMatrix.getInverse(tempMatrix);
             direction.applyMatrix4(tempMatrix);
           }
-  
+
           rotMatrix = new THREE.Matrix4();
           rotMatrix.lookAt(direction, new THREE.Vector3(0, 0, 0), mainAxis.up);
           mainAxis.quaternion.setFromRotationMatrix(rotMatrix);
         }
-  
+
         if (secondAxis)
         {
           if (model.joint[j].axis2.use_parent_model_frame === undefined)
           {
             model.joint[j].axis2.use_parent_model_frame = true;
           }
-  
+
           direction = new THREE.Vector3(
               model.joint[j].axis2.xyz.x,
               model.joint[j].axis2.xyz.y,
               model.joint[j].axis2.xyz.z);
           direction.normalize();
-  
+
           tempMatrix = new THREE.Matrix4();
           if (model.joint[j].axis2.use_parent_model_frame)
           {
@@ -2758,7 +2758,7 @@ export class Scene {
             tempMatrix.getInverse(tempMatrix);
             direction.applyMatrix4(tempMatrix);
           }
-  
+
           secondAxis.position =  direction.multiplyScalar(0.3);
           rotMatrix = new THREE.Matrix4();
           rotMatrix.lookAt(direction, new THREE.Vector3(0, 0, 0), secondAxis.up);
@@ -2783,9 +2783,9 @@ export class Scene {
     {
       return;
     }
-  
+
     var child;
-  
+
     // Visuals already exist
     if (model.COMVisuals)
     {
@@ -2808,12 +2808,12 @@ export class Scene {
         for (var s = 0; s < model.children.length; ++s)
         {
           child = model.getObjectByName(model.children[s].name);
-  
+
           if (!child || child.name === 'boundingBox')
           {
             continue;
           }
-  
+
           child.add(model.COMVisuals[s].crossLines[0]);
           child.add(model.COMVisuals[s].crossLines[1]);
           child.add(model.COMVisuals[s].crossLines[2]);
@@ -2834,11 +2834,11 @@ export class Scene {
       for (var j = 0; j < model.children.length; ++j)
       {
         child = model.getObjectByName(model.children[j].name);
-  
+
         if (!child) {
           continue;
         }
-  
+
         if (child.userData.inertial)
         {
           let inertialPose: Pose = new Pose();
@@ -2847,59 +2847,59 @@ export class Scene {
           let radius: number = 0;
           var mesh = {};
           var inertial = child.userData.inertial;
-  
+
           userdatapose = child.userData.inertial.pose;
           inertialMass = inertial.mass;
-  
+
           // calculate the radius using lead density
           radius = Math.cbrt((0.75 * inertialMass ) / (Math.PI * 11340));
-  
+
           COMVisual = this.COMvisual.clone();
           child.add(COMVisual);
           model.COMVisuals.push(COMVisual);
           COMVisual.scale.set(radius, radius, radius);
-  
+
           var position = new THREE.Vector3(0, 0, 0);
-  
+
           // get euler rotation and convert it to Quaternion
           var quaternion = new THREE.Quaternion();
           var euler = new THREE.Euler(0, 0, 0, 'XYZ');
           quaternion.setFromEuler(euler);
-  
+
           inertialPose = {
             position: position,
             orientation: quaternion
           };
-  
+
           if (userdatapose !== undefined) {
             this.setPose(COMVisual, userdatapose.position,
               userdatapose.orientation);
               inertialPose = userdatapose;
           }
-  
+
           (COMVisual as any).crossLines = [];
-  
+
           // Store link's original rotation (w.r.t. the model)
           var originalRotation = new THREE.Euler();
           originalRotation.copy(child.rotation);
-  
+
           // Align link with world (reverse parent rotation w.r.t. the world)
           child.setRotationFromMatrix(
             new THREE.Matrix4().getInverse(child.parent.matrixWorld));
-  
+
           // Get its bounding box
           box = new THREE.Box3();
-  
+
           box.setFromObject(child);
-  
+
           // Rotate link back to its original rotation
           child.setRotationFromEuler(originalRotation);
-  
+
           // w.r.t child
           var worldToLocal = new THREE.Matrix4();
           worldToLocal.getInverse(child.matrixWorld);
           box.applyMatrix4(worldToLocal);
-  
+
           // X
           points[0] = new THREE.Vector3(box.min.x, inertialPose.position.y,
             inertialPose.position.z);
@@ -2915,35 +2915,35 @@ export class Scene {
             inertialPose.position.y, box.min.z);
           points[5] = new THREE.Vector3(inertialPose.position.x,
             inertialPose.position.y, box.max.z);
-  
+
           helperGeometry_1 = new THREE.BufferGeometry();
           helperGeometry_1.vertices.push(points[0]);
           helperGeometry_1.vertices.push(points[1]);
-  
+
           helperGeometry_2 = new THREE.BufferGeometry();
           helperGeometry_2.vertices.push(points[2]);
           helperGeometry_2.vertices.push(points[3]);
-  
+
           helperGeometry_3 = new THREE.Geometry();
           helperGeometry_3.vertices.push(points[4]);
           helperGeometry_3.vertices.push(points[5]);
-  
+
           helperMaterial = new THREE.LineBasicMaterial({color: 0x00ff00});
-  
+
           line_1 = new THREE.Line(helperGeometry_1, helperMaterial,
               THREE.LineSegments);
           line_2 = new THREE.Line(helperGeometry_2, helperMaterial,
               THREE.LineSegments);
           line_3 = new THREE.Line(helperGeometry_3, helperMaterial,
               THREE.LineSegments);
-  
+
           line_1.name = 'COM_VISUAL';
           line_2.name = 'COM_VISUAL';
           line_3.name = 'COM_VISUAL';
           COMVisual.crossLines.push(line_1);
           COMVisual.crossLines.push(line_2);
           COMVisual.crossLines.push(line_3);
-  
+
           // show lines
           child.add(line_1);
           child.add(line_2);
@@ -2965,14 +2965,14 @@ export class Scene {
     {
       return;
     }
-  
+
     if (model.children.length === 0)
     {
       return;
     }
-  
+
     var child;
-  
+
     // Visuals already exist
     if (model.inertiaVisuals)
     {
@@ -2996,7 +2996,7 @@ export class Scene {
         for (var s = 0; s < model.children.length; ++s)
         {
           child = model.getObjectByName(model.children[s].name);
-  
+
           if (!child || child.name === 'boundingBox')
           {
             continue;
@@ -3018,18 +3018,18 @@ export class Scene {
       for (var j = 0; j < model.children.length; ++j)
       {
         child = model.getObjectByName(model.children[j].name);
-  
+
         if (!child)
         {
           continue;
         }
-  
+
         inertial = child.userData.inertial;
         if (inertial)
         {
           var mesh, boxScale, Ixx, Iyy, Izz, mass, inertia, material = {};
           let inertialPose: Pose;
-  
+
           if (inertial.pose)
           {
             inertialPose = child.userData.inertial.pose;
@@ -3044,14 +3044,14 @@ export class Scene {
             console.warn('Link pose not found!');
             continue;
           }
-  
+
           mass = inertial.mass;
           inertia = inertial.inertia;
           Ixx = inertia.ixx;
           Iyy = inertia.iyy;
           Izz = inertia.izz;
           boxScale = new THREE.Vector3();
-  
+
           if (mass < 0 || Ixx < 0 || Iyy < 0 || Izz < 0 ||
             Ixx + Iyy < Izz || Iyy + Izz < Ixx || Izz + Ixx < Iyy)
           {
@@ -3066,10 +3066,10 @@ export class Scene {
             boxScale.x = Math.sqrt(6*(Izz +  Iyy - Ixx) / mass);
             boxScale.y = Math.sqrt(6*(Izz +  Ixx - Iyy) / mass);
             boxScale.z = Math.sqrt(6*(Ixx  + Iyy - Izz) / mass);
-  
+
             inertiabox = new THREE.Object3D();
             inertiabox.name = 'INERTIA_VISUAL';
-  
+
             // Inertia indicator: equivalent box of uniform density
             mesh = this.createBox(1, 1, 1);
             mesh.name = 'INERTIA_VISUAL';
@@ -3079,11 +3079,11 @@ export class Scene {
             inertiabox.add(mesh);
             inertiabox.name = 'INERTIA_VISUAL';
             child.add(inertiabox);
-  
+
             model.inertiaVisuals.push(inertiabox);
             inertiabox.scale.set(boxScale.x, boxScale.y, boxScale.z);
             inertiabox.crossLines = [];
-  
+
             this.setPose(inertiabox, inertialPose.position,
               inertialPose.orientation);
             // show lines
@@ -3106,19 +3106,19 @@ export class Scene {
             points[5] = new THREE.Vector3(
               2 * boxScale.x + inertialPose.position.x,
               inertialPose.position.y, inertialPose.position.z);
-  
+
             helperGeometry_1 = new THREE.Geometry();
             helperGeometry_1.vertices.push(points[0]);
             helperGeometry_1.vertices.push(points[1]);
-  
+
             helperGeometry_2 = new THREE.Geometry();
             helperGeometry_2.vertices.push(points[2]);
             helperGeometry_2.vertices.push(points[3]);
-  
+
             helperGeometry_3 = new THREE.Geometry();
             helperGeometry_3.vertices.push(points[4]);
             helperGeometry_3.vertices.push(points[5]);
-  
+
             helperMaterial = new THREE.LineBasicMaterial({color: 0x00ff00});
             line_1 = new THREE.Line(helperGeometry_1, helperMaterial,
                 THREE.LineSegments);
@@ -3126,14 +3126,14 @@ export class Scene {
               THREE.LineSegments);
             line_3 = new THREE.Line(helperGeometry_3, helperMaterial,
               THREE.LineSegments);
-  
+
             line_1.name = 'INERTIA_VISUAL';
             line_2.name = 'INERTIA_VISUAL';
             line_3.name = 'INERTIA_VISUAL';
             inertiabox.crossLines.push(line_1);
             inertiabox.crossLines.push(line_2);
             inertiabox.crossLines.push(line_3);
-  
+
             // attach lines
             child.add(line_1);
             child.add(line_2);
@@ -3154,9 +3154,9 @@ export class Scene {
     // TODO: Generalize this and createLight
     var lightObj = entity.children[0];
     var dir;
-  
+
     var color = new THREE.Color();
-  
+
     if (msg.diffuse)
     {
       color.r = msg.diffuse.r;
@@ -3170,7 +3170,7 @@ export class Scene {
       color.g = msg.specular.g;
       color.b = msg.specular.b;
     }
-  
+
     var matrixWorld;
     if (msg.pose)
     {
@@ -3178,7 +3178,7 @@ export class Scene {
       this.setPose(entity, msg.pose.position, msg.pose.orientation);
       entity.matrixWorldNeedsUpdate = true;
     }
-  
+
     if (msg.range)
     {
       // THREE.js's light distance impacts the attenuation factor defined in the
@@ -3189,12 +3189,12 @@ export class Scene {
       // Nevertheless, we identify them for sake of simplicity.
       lightObj.distance = msg.range;
     }
-  
+
     if (msg.cast_shadows)
     {
       lightObj.castShadow = msg.cast_shadows;
     }
-  
+
     if (msg.attenuation_constant)
     {
       // no-op
@@ -3207,7 +3207,7 @@ export class Scene {
     {
       lightObj.intensity = lightObj.intensity/(1+msg.attenuation_quadratic);
     }
-  
+
   //  Not handling these on gzweb for now
   //
   //  if (lightObj instanceof THREE.SpotLight) {
@@ -3218,15 +3218,15 @@ export class Scene {
   //      lightObj.exponent = msg.spot_falloff;
   //    }
   //  }
-  
+
     if (msg.direction)
     {
       dir = new THREE.Vector3(msg.direction.x, msg.direction.y,
           msg.direction.z);
-  
+
       entity.direction = new THREE.Vector3();
       entity.direction.copy(dir);
-  
+
       if (lightObj.target)
       {
         lightObj.target.position.copy(dir);
@@ -3246,24 +3246,24 @@ export class Scene {
       console.error(' No argument provided ');
       return;
     }
-  
+
     var obj = new THREE.Object3D();
-  
+
     var sdfXml = this.spawnModel.sdfParser.parseXML(sdf);
     // sdfXML is always undefined, the XML parser doesn't work while testing
     // while it does work during normal usage.
     var myjson = xmlParser.xml2json(sdfXml, '\t');
     var sdfObj = JSON.parse(myjson).sdf;
-  
+
     var mesh = this.spawnModel.sdfParser.spawnFromSDF(sdf);
     if (!mesh)
     {
       return;
     }
-  
+
     obj.name = mesh.name;
     obj.add(mesh);
-  
+
     return obj;
   }*/
 
@@ -3273,7 +3273,7 @@ export class Scene {
    */
   public addModelLighting(): void {
     this.ambient.color = new THREE.Color(0x666666);
-  
+
     // And light1. Upper back fill light.
     var light1 = this.createLight(3,
       // Diffuse
@@ -3293,7 +3293,7 @@ export class Scene {
       // Specular
       new Color(0.3, 0.3, 0.3, 1.0));
     this.add(light1);
-  
+
     // And light2. Lower back fill light
     var light2 = this.createLight(3,
       // Diffuse
@@ -3313,7 +3313,7 @@ export class Scene {
       // Specular
       new Color(0.3, 0.3, 0.3, 1.0));
     this.add(light2);
-  
+
     // And light3. Front fill light.
     var light3 = this.createLight(3,
       // Diffuse
@@ -3333,7 +3333,7 @@ export class Scene {
       // Specular
       new Color(0.3, 0.3, 0.3, 1.0));
     this.add(light3);
-  
+
     // And light4. Front key light.
     var light4 = this.createLight(3,
       // Diffuse
@@ -3364,23 +3364,23 @@ export class Scene {
   public cleanup(): void {
     let objects: THREE.Object3D[] = [];
     getDescendants(this.scene, objects);
-  
+
     var that = this;
     objects.forEach(function(obj: THREE.Object3D) {
       that.scene.remove(obj);
-  
+
       // Dispose geometries.
       if ((obj as any).geometry) {
         (obj as any).geometry.dispose();
       }
-  
+
       // Dispose materials and their textures.
       if ((obj as any).material) {
         // Materials can be an array. If there is only one, convert it to an array for easier handling.
         if (!((obj as any).material instanceof Array)) {
           (obj as any).material = [(obj as any).material];
         }
-  
+
         // Materials can have different texture maps, depending on their type.
         // We check each property of the Material and dispose them if they are Textures.
         (obj as any).material.forEach(function(material: any) {
@@ -3389,12 +3389,12 @@ export class Scene {
               material[property].dispose();
             }
           });
-  
+
           material.dispose();
         });
       }
     });
-  
+
     // Clean scene and renderer.
     this.renderer.renderLists.dispose();
     this.renderer.dispose();
@@ -3409,11 +3409,11 @@ export class Scene {
   public setRequestHeader(header: string, value: string): void {
     // ES6 syntax for computed object keys.
     const headerObject = { [header]: value };
-  
+
     this.textureLoader.requestHeader = headerObject;
     this.colladaLoader.requestHeader = headerObject;
     this.stlLoader.requestHeader = headerObject;
-  
+
     this.requestHeader = headerObject;
 
     // Change the texture loader, if the requestHeader is present.
@@ -3430,7 +3430,7 @@ export class Scene {
         let image: HTMLImageElement =
           <HTMLImageElement>(document.createElementNS(
             'http://www.w3.org/1999/xhtml', 'img'));
-  
+
         // Once the image is loaded, we need to revoke the ObjectURL.
         image.onload = function () {
           image.onload = null;
@@ -3442,9 +3442,9 @@ export class Scene {
             onLoad(texture);
           }
         };
-  
+
         image.onerror = onError as any;
-  
+
         // Once the image is loaded, we need to revoke the ObjectURL.
         fileLoader.load(
           url,
@@ -3454,7 +3454,7 @@ export class Scene {
           onProgress,
           onError
         );
-  
+
         return texture;
       };
     }
@@ -3495,20 +3495,20 @@ export class Scene {
          // Create the image element
          let imageElem: HTMLImageElement = <HTMLImageElement>(
            document.createElementNS('http://www.w3.org/1999/xhtml', 'img'));
-  
+
          var isJPEG = map.search( /\.jpe?g($|\?)/i ) > 0 || map.search( /^data\:image\/jpeg/ ) === 0;
-  
-         var binary = ''; 
+
+         var binary = '';
          var len = image.byteLength;
          for (var i = 0; i < len; i++) {
            binary += String.fromCharCode(image[i]);
          }
-  
+
          // Set the image source using base64 encoding
          imageElem.src = isJPEG ? 'data:image/jpg;base64,' :
            'data:image/png;base64,';
          imageElem.src += window.btoa(binary);
-  
+
          texture.format = isJPEG ? THREE.RGBFormat : THREE.RGBAFormat;
          texture.needsUpdate = true;
          texture.image = imageElem;

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -16,7 +16,7 @@ import { Transport } from './Transport';
  * element with the id ELEMENT_ID
  *
  * ```
- * let sceneMgr = new SceneManager(ELEMENT_ID, WS_URL, WS_KEY); 
+ * let sceneMgr = new SceneManager(ELEMENT_ID, WS_URL, WS_KEY);
  * ```
  */
 export class SceneManager {
@@ -180,7 +180,7 @@ export class SceneManager {
    */
   public disconnect(): void {
     // Remove the canvas. Helpful to disconnect and connect several times.
-    if (this.sceneElement && this.sceneElement.childElementCount > 0) {
+    if (this.sceneElement?.childElementCount > 0 && this.scene.scene.renderer?.domElement) {
       this.sceneElement.removeChild(this.scene.scene.renderer.domElement);
     }
 
@@ -210,7 +210,6 @@ export class SceneManager {
     this.transport.connect(url, key);
 
     this.statusSubscription = this.transport.status$.subscribe((response) => {
-
       if (response === 'error') {
         // TODO: Return an error so the caller can open a snackbar
         console.log('Connection failed. Please contact an administrator.');
@@ -298,7 +297,7 @@ export class SceneManager {
           if (entity) {
             this.scene.setPose(entity, pose.position, pose.orientation);
           } else {
-            console.warn('Unable to find entity with name ', entityName, entity); 
+            console.warn('Unable to find entity with name ', entityName, entity);
           }
         });
       }
@@ -359,7 +358,6 @@ export class SceneManager {
    * Setup the visualization scene.
    */
   private setupVisualization(): void {
-
     var that = this;
 
     // Create a find asset helper

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -25,7 +25,7 @@ export class Transport {
   /**
    * The Websocket object.
    */
-  private ws: WebSocket; 
+  private ws: WebSocket;
 
   /**
    * The root namespace should be obtained from the Websocket upon connection.


### PR DESCRIPTION
This PR introduces a couple of changes. I highly recommend to check the following commits, instead of the whole diff:

---

## Changes

- Trim extra spaces that were added to files.
- Refactor `getDescendants`. Commit: 11ecd3b299f2b7f516cdff6ce5bbfb45a06cee2a
  - This is a minor change that can be omitted, but I think it's a good thing to raise awareness of.
- Small tweaks to FuelServer to check both `ignitionrobotics` and `gazebosim` URLs. Commit: cda1daa1bf70cf666b97d414c8172ab6be05dc15
- Rewrite `printGraph()` method. Commit: 5f002aae0aa8263e00db274e093efb6e69d5dc54
- Heightmaps. Commit: 59309939bf0443656607815e1389ca8ae1330c0e
  - Use `let` and `const` instead of `var`.
  - Style updates.
  - **Important**: Default values for `blend`. Otherwise, if it's undefined, it fails.

## Note

This PR aims to `heightmap`. We should update `gzweb2` with `heightmap` and `update-scene` first.

---

Can you ptal at those commits @nkoenig ?