### PR TITLE
Expose subscription to topics in Scene Manager

### DIFF
--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -299,8 +299,20 @@ export class SceneManager {
   }
 
   /**
-   * Subscribe to Gazebo topics required to render a scene. This include
-   * /world/WORLD_NAME/dynamic_pose/info and /world/WORLD_NAME/scene/info
+   * Allows clients to subscribe to a custom topic.
+   *
+   * @param topic The topic to subscribe to.
+   */
+  public subscribeToTopic(topic: Topic): void {
+    this.transport.subscribe(topic);
+  }
+
+  /**
+   * Subscribe to Gazebo topics required to render a scene.
+   *
+   * This include:
+   * - /world/WORLD_NAME/dynamic_pose/info
+   * - /world/WORLD_NAME/scene/info
    */
   private subscribeToTopics(): void {
     // Subscribe to the pose topic and modify the models' poses.

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -312,7 +312,7 @@ export class SceneManager {
    *
    * @param name The name of the topic to unsubscribe from.
    */
-   public unsubscribeToTopic(name: string): void {
+  public unsubscribeToTopic(name: string): void {
     this.transport.unsubscribe(name);
   }
 

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -312,7 +312,7 @@ export class SceneManager {
    *
    * @param name The name of the topic to unsubscribe from.
    */
-  public unsubscribeToTopic(name: string): void {
+  public unsubscribeFromTopic(name: string): void {
     this.transport.unsubscribe(name);
   }
 

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -308,6 +308,15 @@ export class SceneManager {
   }
 
   /**
+   * Allows clients to unsubscribe from topics.
+   *
+   * @param name The name of the topic to unsubscribe from.
+   */
+   public unsubscribeToTopic(name: string): void {
+    this.transport.unsubscribe(name);
+  }
+
+  /**
    * Subscribe to Gazebo topics required to render a scene.
    *
    * This include:

--- a/src/Topic.ts
+++ b/src/Topic.ts
@@ -18,7 +18,7 @@ export class Topic {
   /**
    * Optional. Function to be called when unsubscribing from the topic.
    */
-   unsubscribe?(): any;
+  unsubscribe?(): any;
 
   constructor(name: string, cb: TopicCb) {
     this.name = name;


### PR DESCRIPTION
This PR exposes topic subscription to clients. This is required for clients to subscribe to custom topics, such as `/speed`.

Currently, `Transport` is a private member of the Scene Manager, so a new method in the Scene Manager is implemented.

Can you ptal @clalancette ?