### PR TITLE
Connection Status as an Observable

### DIFF
--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -3,7 +3,7 @@ import { AudioTopic } from './AudioTopic';
 import { Scene } from './Scene';
 import { SDFParser } from './SDFParser';
 import { Shaders } from './Shaders';
-import { Observable, Subscription } from 'rxjs';
+import { map, Observable, Subscription } from 'rxjs';
 import { Topic } from './Topic';
 import { Transport } from './Transport';
 
@@ -159,12 +159,15 @@ export class SceneManager {
 
   /**
    * Get the connection status as an observable.
-   * Allows clients to subscribe to this stream, to act upon changes in connection status.
+   * Allows clients to subscribe to this stream, to let them know when the connection to Gazebo
+   * is ready for communication.
    *
-   * @returns An Observable of the connection status (string).
+   * @returns An Observable of a boolean: Whether the connection status is ready or not.
    */
-  public getConnectionStatusAsObservable(): Observable<string> {
-    return this.transport.status$.asObservable();
+  public getConnectionStatusAsObservable(): Observable<boolean> {
+    return this.transport.getConnectionStatus().pipe(
+      map((status) => status === 'ready'),
+    );
   }
 
   /**

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -3,7 +3,7 @@ import { AudioTopic } from './AudioTopic';
 import { Scene } from './Scene';
 import { SDFParser } from './SDFParser';
 import { Shaders } from './Shaders';
-import { Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { Topic } from './Topic';
 import { Transport } from './Transport';
 
@@ -155,6 +155,16 @@ export class SceneManager {
    */
   public getConnectionStatus(): string {
     return this.connectionStatus;
+  }
+
+  /**
+   * Get the connection status as an observable.
+   * Allows clients to subscribe to this stream, to act upon changes in connection status.
+   *
+   * @returns An Observable of the connection status (string).
+   */
+  public getConnectionStatusAsObservable(): Observable<string> {
+    return this.transport.status$.asObservable();
   }
 
   /**

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -258,7 +258,7 @@ export class SceneManager {
   public connect(url: string, key?: string): void {
     this.transport.connect(url, key);
 
-    this.statusSubscription = this.transport.status$.subscribe((response) => {
+    this.statusSubscription = this.transport.getConnectionStatus().subscribe((response) => {
       if (response === 'error') {
         // TODO: Return an error so the caller can open a snackbar
         console.log('Connection failed. Please contact an administrator.');

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { Root, Type, parse } from 'protobufjs';
 import { Topic } from './Topic';
 import { Asset, AssetCb } from './Asset';
@@ -8,13 +8,6 @@ import { Asset, AssetCb } from './Asset';
  * Gazebo websocket server.
  */
 export class Transport {
-
-  /**
-   * Status connection behavior subject.
-   * Components can subscribe to it to get connection status updates.
-   * Uses a Behavior Subject because it has an initial state and stores a value.
-   */
-  public status$ = new BehaviorSubject<string>('disconnected');
 
   /**
    * Scene Information behavior subject.
@@ -60,6 +53,13 @@ export class Transport {
    * The world that is being used in the Simulation.
    */
   private world: string = '';
+
+  /**
+   * Status connection behavior subject.
+   * Internally keeps track of the connection state.
+   * Uses a Behavior Subject because it has an initial state and stores a value.
+   */
+  private status$ = new BehaviorSubject<string>('disconnected');
 
   /**
    * Connects to a websocket.
@@ -224,6 +224,13 @@ export class Transport {
     }
 
     this.ws.send(this.buildMsg(msg));
+  }
+
+  /**
+   * Exposes the connection status as an Observable.
+   */
+  public getConnectionStatus(): Observable<string> {
+    return this.status$.asObservable();
   }
 
   /**


### PR DESCRIPTION
Addresses [GzWeb to communicate simulation status](https://app.asana.com/0/0/1202738194148095/f).

---

The Connection Status is now available as an Observable. This allows clients to subscribe to status changes.

## Use case

Clients should subscribe to certain topics, such as `/speed`, only when the connection status is "ready", otherwise, the subscription is ignored.

---

Can you ptal @clalancette or @quiquequique ?