### PR TITLE
Allow the user to move the third-person camera

### DIFF
--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -957,7 +957,7 @@ export class Scene {
   /**
    * Render scene
    */
-  public render(): void {
+  public render(timeElapsedMs: number): void {
     // Kill camera control when:
     // -manipulating
     // -using radial menu
@@ -1082,7 +1082,7 @@ export class Scene {
     }
 
     this.renderer.setSize(width, height);
-    this.render();
+    this.render(0);
   }
 
   /**
@@ -2283,7 +2283,7 @@ export class Scene {
   {
     // An explicit call to render is required. Otherwise the obtained image will be black.
     // See https://threejsfundamentals.org/threejs/lessons/threejs-tips.html, "Taking A Screenshot of the Canvas"
-    this.render();
+    this.render(0);
 
     this.getDomElement().toBlob(function(blob: any) {
       let url = URL.createObjectURL(blob);
@@ -2339,7 +2339,7 @@ export class Scene {
     this.camera.position.add(new THREE.Vector3(1.6, -1.6, 1.2));
     this.camera.lookAt(center);
     light.position.copy(this.camera.position);
-    this.render();
+    this.render(0);
     const perspective = getCanvasBlob(canvas);
     perspective.then(function(blob) {
       zip.file('thumbnails/1.png', <Blob>(blob));
@@ -2351,7 +2351,7 @@ export class Scene {
     this.camera.position.add(new THREE.Vector3(0, 0, 2.2));
     this.camera.rotation.copy(new THREE.Euler(0, 0, -90 * Math.PI / 180));
     light.position.copy(this.camera.position);
-    this.render();
+    this.render(0);
     const top = getCanvasBlob(canvas);
     top.then(function(blob) {
       zip.file('thumbnails/2.png', <Blob>(blob));
@@ -2363,7 +2363,7 @@ export class Scene {
     this.camera.position.add(new THREE.Vector3(2.2, 0, 0));
     this.camera.rotation.copy(new THREE.Euler(0, 90 * Math.PI / 180, 90 * Math.PI / 180));
     light.position.copy(this.camera.position);
-    this.render();
+    this.render(0);
     const front = getCanvasBlob(canvas);
     front.then(function(blob) {
       zip.file('thumbnails/3.png', <Blob>(blob));
@@ -2375,7 +2375,7 @@ export class Scene {
     this.camera.position.add(new THREE.Vector3(0, 2.2, 0));
     this.camera.rotation.copy(new THREE.Euler(-90 * Math.PI / 180, 0, 180 * Math.PI / 180));
     light.position.copy(this.camera.position);
-    this.render();
+    this.render(0);
     const side = getCanvasBlob(canvas);
     side.then(function(blob) {
       zip.file('thumbnails/4.png', <Blob>(blob));
@@ -2388,7 +2388,7 @@ export class Scene {
     this.camera.rotation.copy(new THREE.Euler(90 * Math.PI / 180, -90 * Math.PI / 180, 0));
     light.position.copy(this.camera.position);
     light.position.add(new THREE.Vector3(-2000, 0, 0));
-    this.render();
+    this.render(0);
     const back = getCanvasBlob(canvas);
     back.then(function(blob) {
       zip.file('thumbnails/5.png', <Blob>(blob));

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -766,10 +766,9 @@ export class Scene {
       // do the inverse of what we do in render, namely:
       // 1. subtract the position of the tracked object
       // 2. Apply the inverse (conjugate) quaternion of the tracked object
-      let cameraOffset = this.camera.position;
-      cameraOffset.sub(this.cameraTrackObject.position);
-      cameraOffset.applyQuaternion(this.cameraTrackObject.quaternion.conjugate());
-      this.currentThirdPersonCameraOffset.copy(cameraOffset);
+      this.currentThirdPersonCameraOffset = this.camera.position.clone();
+      this.currentThirdPersonCameraOffset.sub(this.cameraTrackObject.position);
+      this.currentThirdPersonCameraOffset.applyQuaternion(this.cameraTrackObject.quaternion.conjugate());
     }
 
     // Clicks (<150ms) outside any models trigger view mode
@@ -1031,7 +1030,7 @@ export class Scene {
       // The calculation here comes from:
       // https://github.com/simondevyoutube/ThreeJS_Tutorial_ThirdPersonCamera/blob/main/main.js
       const timeElapsedSec = timeElapsedMs * 0.001;
-      const timestep = 1.0 - Math.pow(0.001, timeElapsedSec);
+      const timestep = 2.0 * timeElapsedSec;
 
       this.currentThirdPersonLookAt.lerp(fixedLookAt, timestep);
 

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -186,25 +186,25 @@ export class SceneManager {
     }
   }
 
-  public follow(entityName: String): void {
+  public follow(entityName: string): void {
     if (this.scene) {
       this.scene.emitter.emit('follow_entity', entityName);
     }
   }
 
-  public thirdPersonFollow(entityName: String): void {
+  public thirdPersonFollow(entityName: string): void {
     if (this.scene) {
       this.scene.emitter.emit('third_person_follow_entity', entityName);
     }
   }
 
-  public moveTo(entityName: String): void {
+  public moveTo(entityName: string): void {
     if (this.scene) {
       this.scene.emitter.emit('move_to_entity', entityName);
     }
   }
 
-  public select(entityName: String): void {
+  public select(entityName: string): void {
     if (this.scene) {
       this.scene.emitter.emit('select_entity', entityName);
     }

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -95,6 +95,11 @@ export class SceneManager {
   private cancelAnimation: number;
 
   /**
+   *
+   */
+  private previousRenderTimestampMs: number = 0;
+
+  /**
    * The container of the Scene.
    */
   private sceneElement: HTMLElement;
@@ -144,6 +149,8 @@ export class SceneManager {
     if (this.cancelAnimation) {
       cancelAnimationFrame(this.cancelAnimation);
     }
+
+    this.previousRenderTimestampMs = 0;
 
     if (this.scene) {
       this.scene.cleanup();
@@ -433,18 +440,23 @@ export class SceneManager {
     this.scene.setSize(this.sceneElement.clientWidth, this.sceneElement.clientHeight);
   }
 
+  private RAF(): void {
+    this.cancelAnimation = requestAnimationFrame((timestampMs) => {
+      if (this.previousRenderTimestampMs === 0) {
+        this.previousRenderTimestampMs = timestampMs;
+      }
+
+      this.RAF();
+
+      this.scene.render(timestampMs - this.previousRenderTimestampMs);
+      this.previousRenderTimestampMs = timestampMs;
+    });
+  }
+
   /**
    * Start the visualization rendering loop.
    */
   private startVisualization(): void {
-    // Render loop.
-    const animate = () => {
-      this.scene.render();
-      this.cancelAnimation = requestAnimationFrame(() => {
-        animate();
-      });
-    };
-
-    animate();
+    this.RAF();
   }
 }


### PR DESCRIPTION
This PR makes improvements to the third-person camera support that was merged in #20 .  In particular, it does the following two things:

1. It fixes a nasty bug where we were miscalculating the time between frames, meaning that the camera movement was much shakier than it was before.
2. It allows the user to move the camera while in third-person follow mode, and then will use that new fixed offset for the camera going forward.  This allows users to readjust where they are watching from.

In order to do the first thing, there is a slight revamp of the logic around `requestAnimationFrame` so that we get the timestamp at which the callback was started.

In my testing, with this and https://github.com/osrf/pounce-web/pull/14 applied, this works fairly well.  There is still a small bug where the camera is jerky the first few seconds after a camera move.  It fixes itself, but it is kind of ugly.  I'll look into that separately.