### PR TITLE
Release 2.0.12 beta30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gzweb",
-  "version": "2.0.12-beta.29",
+  "version": "2.0.12-beta.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gzweb",
-      "version": "2.0.12-beta.29",
+      "version": "2.0.12-beta.30",
       "dependencies": {
         "eventemitter2": "^6.4.5",
         "jszip": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gzweb",
-  "version": "2.0.12-beta.29",
+  "version": "2.0.12-beta.30",
   "description": "A library for Gazebo and data visualization.",
   "type": "module",
   "main": "dist/gzweb.js",


### PR DESCRIPTION
This PR updates `gzweb` to `2.0.12 beta30`, in order to publish a version on npm.