### PR TITLE
Clean Scene constructor's arguments

### DIFF
--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -31,7 +31,7 @@ enum JointTypes {
 }
 
 /**
- * Interface of optional arguments for the Scene's constructor.
+ * Interface of arguments for the Scene's constructor.
  */
 export interface SceneConfig {
   shaders: Shaders;

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -31,6 +31,17 @@ enum JointTypes {
 }
 
 /**
+ * Interface of optional arguments for the Scene's constructor.
+ */
+export interface SceneConfig {
+  shaders: Shaders;
+  defaultCameraPosition?: THREE.Vector3;
+  defaultCameraLookAt?: THREE.Vector3;
+  backgroundColor?: THREE.Color;
+  findResourceCb?: FindResourceCb;
+}
+
+/**
  * The scene is where everything is placed, from objects, to lights and cameras.
  *
  * Supports radial menu on an orthographic scene when gzradialmenu.js has been
@@ -106,31 +117,27 @@ export class Scene {
   private mousePointerDown: boolean = false;
   private currentFirstPersonLookAt = new THREE.Vector3();
 
-  constructor(shaders: Shaders, defaultCameraPosition?: THREE.Vector3,
-              defaultCameraLookAt?: THREE.Vector3,
-              backgroundColor?: THREE.Color,
-              findResourceCb?: FindResourceCb)
-  {
+  constructor(config: SceneConfig) {
     this.emitter = new EventEmitter2({verboseMemoryLeak: true});
-    this.shaders = shaders;
-    if (findResourceCb) {
-      this.findResourceCb = findResourceCb;
+    this.shaders = config.shaders;
+    if (config.findResourceCb) {
+      this.findResourceCb = config.findResourceCb;
     }
 
     // This matches Gazebo's default camera position
     this.defaultCameraPosition = new THREE.Vector3(-6, 0, 6);
-    if (defaultCameraPosition) {
-      this.defaultCameraPosition.copy(defaultCameraPosition);
+    if (config.defaultCameraPosition) {
+      this.defaultCameraPosition.copy(config.defaultCameraPosition);
     }
 
     this.defaultCameraLookAt = new THREE.Vector3(0, 0, 0);
-    if (defaultCameraLookAt) {
-      this.defaultCameraLookAt.copy(defaultCameraLookAt);
+    if (config.defaultCameraLookAt) {
+      this.defaultCameraLookAt.copy(config.defaultCameraLookAt);
     }
 
     this.backgroundColor = new THREE.Color(0xb2b2b2);
-    if (backgroundColor) {
-      this.backgroundColor.copy(backgroundColor);
+    if (config.backgroundColor) {
+      this.backgroundColor.copy(config.backgroundColor);
     }
 
     this.init();

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -543,8 +543,10 @@ export class SceneManager {
       that.transport.getAsset(_uri, _cb);
     }
 
-    this.scene = new Scene(new Shaders(), undefined, undefined,
-                           undefined, findAsset);
+    this.scene = new Scene({
+      shaders: new Shaders(),
+      findResourceCb: findAsset,
+    });
     this.sdfParser = new SDFParser(this.scene);
     this.sdfParser.usingFilesUrls = true;
 


### PR DESCRIPTION
This PR handles the Scene's arguments in an interface. We no longer need to explicitly pass `undefined` to unused arguments.

Note that Interfaces do not have default values. They only provide required and optional fields, and their types. The Scene constructor needs to set those default values accordingly.

Can you ptal @nkoenig ? This was part of the changes related to handling websocket assets, but it's cleaner to have on its own.