### PR TITLE
Websocket Loading Manager

### DIFF
--- a/include/ColladaLoader.js
+++ b/include/ColladaLoader.js
@@ -62,12 +62,12 @@ index cea5ac1..1980da1 100644
  	Skeleton,
  	SkinnedMesh,
 @@ -1644,14 +1645,14 @@ class ColladaLoader extends Loader {
- 
+
  					if ( loader !== undefined ) {
- 
+
 -						const texture = loader.load( image );
 +						let texture;
- 
+
  						// Check against the cache, if enabled.
  						if (scope.enableTexturesCache && scope.texturesCache.has(image)) {
  							texture = scope.texturesCache.get(image);
@@ -81,7 +81,7 @@ index cea5ac1..1980da1 100644
 @@ -1689,7 +1690,7 @@ class ColladaLoader extends Loader {
                        imageElem.src = isJPEG ? "data:image/jpg;base64,": "data:image/png;base64,";
                        imageElem.src += window.btoa(binary);
- 
+
 -                      scopeTexture.format = isJPEG ? THREE.RGBFormat : THREE.RGBAFormat;
 +                      scopeTexture.format = isJPEG ? RGBFormat : RGBAFormat;
                        scopeTexture.needsUpdate = true;
@@ -90,15 +90,15 @@ index cea5ac1..1980da1 100644
 @@ -4216,9 +4217,9 @@ class ColladaLoader extends Loader {
  		const scene = parseScene( getElementsByTagName( collada, 'scene' )[ 0 ] );
  		scene.animations = animations;
- 
+
 -		if ( asset.upAxis === 'Z_UP' ) {
 +		if ( asset.upAxis === 'Y_UP' ) {
- 
+
 -			scene.quaternion.setFromEuler( new Euler( - Math.PI / 2, 0, 0 ) );
 +			scene.quaternion.setFromEuler( new Euler( Math.PI / 2, 0, 0 ) );
- 
+
  		}
- * 
+ *
  *
  *
  * Modified by Nate Koenig :
@@ -1711,7 +1711,7 @@ class ColladaLoader extends Loader {
 							if (image.startsWith('https://')) {
 								loader.path = undefined;
 							}
-              
+
 							texture = loader.load(image,
                 // onLoad
                 undefined,
@@ -1723,12 +1723,17 @@ class ColladaLoader extends Loader {
                     // Create the filename to look up.
                     var filename = [path.substring(0, path.lastIndexOf("/")),
                       image].join("/");
-                
+
                     // Store the texture pointer
                     var scopeTexture = texture;
 
                     // Get the image using the find resource callback.
-                    scope.findResourceCb(filename, function(image) {
+                    scope.findResourceCb(filename, (image, error) => {
+                      if (error !== undefined) {
+                        // Mark the texture as error in the loading manager.
+                        loader.manager.markAsError(filename);
+                        return;
+                      }
                       // Create the image element
                       var imageElem = document.createElementNS(
                         'http://www.w3.org/1999/xhtml', 'img');
@@ -1747,6 +1752,9 @@ class ColladaLoader extends Loader {
                       scopeTexture.format = isJPEG ? RGBFormat : RGBAFormat;
                       scopeTexture.needsUpdate = true;
                       scopeTexture.image = imageElem;
+
+                      // Mark the texture as done in the loading manager.
+                      loader.manager.markAsDone(filename);
                     });
                   }
                 });
@@ -4296,4 +4304,3 @@ class ColladaLoader extends Loader {
 }
 
 export { ColladaLoader };
-

--- a/src/Asset.ts
+++ b/src/Asset.ts
@@ -1,9 +1,13 @@
-export type AssetCb = (msg: any) => void;
+export type AssetCb = (msg: any, error?: any) => void;
+
+export enum AssetError {
+  NOT_FOUND = 'asset_not_found',
+  URI_MISSING = 'asset_uri_missing',
+};
 
 /**
  * Type that represents a simulation asset that needs to be fetched from a websocket server.
  */
-
 export class Asset {
   /**
    * The URI of the asset file to be fetched.
@@ -12,6 +16,7 @@ export class Asset {
 
   /**
    * Callback that is used when the asset has been fetched.
+   * Contains the asset and an error, if found.
    */
   public cb: AssetCb;
 

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -5,7 +5,7 @@ import { Topic } from './Topic';
 import { Asset, AssetCb } from './Asset';
 
 /**
- * The Trasnport class is in charge of managing the websocket connection to a
+ * The Transport class is in charge of managing the websocket connection to a
  * Gazebo websocket server.
  */
 export class Transport {
@@ -418,9 +418,9 @@ export class Transport {
         // Run the callback associated with the asset. This lets the requester
         // process the asset message.
         if (this.assetMap.has(frameParts[1])) {
-          this?.assetMap?.get(frameParts[1])?.cb(msg['data']);
+          this.assetMap.get(frameParts[1])!.cb(msg['data']);
         } else {
-          console.error('No resource callback');
+          console.error(`No resource callback for ${this.assetMap.get(frameParts[1])!.uri}`);
         }
       } else if (frameParts[0] == 'pub') {
 

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -250,6 +250,8 @@ export class Transport {
       cb: _cb
     };
 
+    console.log(`Getting asset via websocket - ${_uri}`);
+
     this.assetMap.set(_uri, asset);
     this.sendMessage(['asset', '', '', _uri]);
   }

--- a/src/WsLoadingManager.ts
+++ b/src/WsLoadingManager.ts
@@ -1,0 +1,171 @@
+import { LoadingManager } from "three";
+
+/**
+ * The Websocket Loading Manager is a custom Loading Manager that keeps track
+ * of items that need to be loaded via the websocket server.
+ *
+ * Usually, when a loader fails to load an item, it marks it as done. This
+ * manager handles that particular case: It doesn't mark the item as done
+ * until it comes back from the websocket connection.
+ *
+ * Loading Managers handle and keep track of loaded and pending items.
+ * For more information, see https://threejs.org/docs/#api/en/loaders/managers/LoadingManager
+ */
+export class WsLoadingManager extends LoadingManager {
+
+  /**
+   * Callback used when the first item starts loading.
+   */
+  public onStart: ((url: string, loaded: number, total: number) => void) | undefined;
+
+  /**
+   * LoadingManager method.
+   * Called whenever a new item is being loaded by the Loader that has this manager.
+   */
+  public itemStart: (url: string) => void;
+
+  /**
+   * LoadingManager method.
+   * Called whenever the Loader finishes loading an item (regardless of error status).
+   */
+  public itemEnd: (url: string) => void;
+
+  /**
+   * LoadingManager method.
+   * Called whenever the Loader had an error while loading an item.
+   */
+  public itemError: (url: string) => void;
+
+  /**
+   * Array of URLs that had an error related to the Loader.
+   * This manager keeps track of these because we need to try to get them from the websocket server.
+   */
+  private errorItems: string[] = [];
+
+  /**
+   * The number of items loaded. Used to determine progress.
+   */
+  private itemsLoaded: number = 0;
+
+  /**
+   * The total number of items to load. Used to determine progress.
+   */
+  private itemsTotal: number = 0;
+
+  /**
+   * Determine whether items are being loaded or not.
+   * Once the loaded items equal the total, we consider the loading to be done.
+   */
+  private isLoading: boolean = false;
+
+  /**
+   * Note: The onLoad, onProgress and onError methods have nothing to do with the Loader that has
+   * this manager.
+   *
+   * @param onLoad Callback when all the items are loaded.
+   * @param onProgress Callback when an item is loaded.
+   * @param onError Callback when there is an error getting the item from the websocket server. See {@link markAsError}.
+   */
+  constructor(
+    onLoad?: () => void,
+    onProgress?: (url: string, loaded: number, total: number) => void,
+    onError?: (url: string) => void
+  ) {
+    super(onLoad, onProgress, onError);
+
+    /**
+     * itemStart method is called internally by loaders using this manager, whenever they start
+     * getting the resource.
+     */
+    this.itemStart = (url) => {
+      this.itemsTotal++;
+
+      if (!this.isLoading) {
+        if (this.onStart !== undefined) {
+          this.onStart(url, this.itemsLoaded, this.itemsTotal);
+        }
+        this.isLoading = true;
+      }
+    };
+
+    /**
+     * itemEnd method is called internally by loaders using this manager, whenever they finish
+     * loading the resource they where trying to load.
+     *
+     * This is called whether the resource had an error or not.
+     */
+    this.itemEnd = (url) => {
+      // This manager keeps track of the items that had errors. We don't want to mark them as done,
+      // as they need to be get from the websocket server.
+      if (this.errorItems.includes(url)) {
+        return;
+      }
+
+      // No error - Proceed to end the item.
+      this.itemsLoaded++;
+
+      if (onProgress !== undefined) {
+        onProgress(url, this.itemsLoaded, this.itemsTotal);
+      }
+
+      if (this.itemsLoaded === this.itemsTotal) {
+        this.isLoading = false;
+        if (onLoad !== undefined) {
+          onLoad();
+        }
+      }
+    };
+
+    /**
+     * itemError method is called internally by loaders using this manager, whenever the resource
+     * they are trying to load fails.
+     */
+    this.itemError = (url) => {
+      // This manager keeps track of the items that had errors. We don't want to mark them as error until we tried
+      // getting the resource from the websocket server.
+      if (!this.errorItems.includes(url)) {
+        this.errorItems.push(url);
+        return;
+      }
+
+      if (onError !== undefined) {
+        onError(url);
+      }
+    };
+  }
+
+  /**
+   * Mark an item as Done.
+   * This method should be called manually when the websocket connection successfully gets the item.
+   *
+   * @param url The URL of the resource.
+   */
+  public markAsDone(url: string): void {
+    if (this.errorItems.includes(url)) {
+      this.filterAndEnd(url);
+    }
+  }
+
+  /**
+   * Mark an item as Error.
+   * This method should be called manually when the websocket connection fails to get the item.
+   *
+   * @param url The URL of the resource.
+   */
+  public markAsError(url: string): void {
+    if (this.errorItems.includes(url)) {
+      this.itemError(url);
+      this.filterAndEnd(url);
+    }
+  }
+
+  /**
+   * Internal method that removes an URL from the error items array and ends it.
+   *
+   * @param url The URL of the resource.
+   */
+  private filterAndEnd(url: string): void {
+    this.errorItems = this.errorItems.filter((errorUrl: string) => errorUrl !== url);
+    this.itemEnd(url);
+  }
+}


### PR DESCRIPTION
This PR solves the issue of keeping track of assets loaded via the websocket server. This is required for clients to have a "loading" behavior available.

---

### Context

[Loaders](https://threejs.org/docs/#api/en/loaders/Loader) are in charge of loading, parsing and using any kind of resource. They have a [loading manager](https://threejs.org/docs/#api/en/loaders/managers/LoadingManager), which is usually a default one unless provided.

The Loading Managers are in charge of handling and keeping track of loaded and pending data. Whenever a resource begins to being fetched, it increases the number of total items handled. When an item ends, the number of loaded items increases. Then, when the number of loaded items equals the total, the loading manager considers it has finished. 

Here's the current workflow that happens whenever we call a Loader's load method. The diagram is only meant to be a guide.

![pounceMinimap drawio (8)](https://user-images.githubusercontent.com/14120807/189348937-e29a8f86-5a65-4b41-9686-bfa3157b7137.png)

When a loader's `load` method fails, we use its `onError` callback to handle the asset via the websocket server. At this point, the loader manager already marked the item as error, and called it's end.

---

### Solution

We now use a custom Loading Manager to avoid marking items as done whenever their loader fails.

If we use the websocket connection to get assets, we need to provide a new `WsLoadingManager` to loaders.

The `WsLoadingManager` extends a Loading Manager and allows it to keep track of the items the loaders tried to load and failed to do so. This way, when `itemError` is called, we keep track of the item, and when `itemEnd` is called, we know it had an error, so we don't mark it as done (yet).

When we get the asset from the websocket callback, we can manually mark it as done. Or, mark it as error, if we failed to get it.

![pounceMinimap drawio (9)](https://user-images.githubusercontent.com/14120807/189354022-1cf2519b-9ae7-4629-9127-45b7625c811d.png)

---

This is a very non-intrusive way to handle assets via websocket connections. This way _we don't have to modify loaders directly_, which is something that is very hard to keep track of.

_Note:_ Our ColladaLoader still uses the websocket callback inside of it and had to be modified, but I'm quite sure it can be avoided. We can modify it in the future if needed.

---

Another potential way to solve this issue is to have a Loader class that encompasses regular loaders with the websocket fallback, but it has been quite challenging to do. This is the easiest way I found to bring a solution to this problem.

---

Can you ptal @nkoenig ?