### PR TITLE
Support red skybox

### DIFF
--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -682,18 +682,27 @@ export class Scene {
     this.COMvisual.add(mesh);
   }
 
-  public addSky(): void {
+  public addSky(cubemap: string | undefined): void {
     var cubeLoader = new THREE.CubeTextureLoader();
-    var cubeTexture = cubeLoader.load([
-      'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-negx.jpg',
-      'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-posx.jpg',
-      'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-posy.jpg',
-      'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-negy.jpg',
-      'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-negz.jpg',
-      'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-posz.jpg',
-    ]);
-
-    this.scene.background = cubeTexture;
+    if (cubemap === undefined) {
+      this.scene.background = cubeLoader.load([
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-negx.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-posx.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-posy.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-negy.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-negz.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-posz.jpg',
+      ]);
+    } else {
+      this.scene.background = cubeLoader.load([
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-red-negx.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-red-posx.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-red-posy.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-red-negy.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-red-negz.jpg',
+        'https://fuel.gazebosim.org/1.0/openrobotics/models/skybox/tip/files/materials/textures/skybox-red-posz.jpg',
+      ]);
+    }
   }
 
   public initScene(): void {

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -362,13 +362,14 @@ export class SceneManager {
         const sky = sceneInfo['sky'];
 
         // Check to see if a cubemap has been specified in the header.
-        if (sky['header'] !== undefined &&
-            sky['header']['data'] !== undefined) {
+        if ('header' in sky && sky['header'] !== null && sky['header'] !== undefined &&
+            'data' in sky['header'] && sky['header']['data'] !== null && sky['header']['data'] !== undefined) {
           const data = sky['header']['data'];
           for (let i = 0; i < data.length; ++i) {
             if (data[i]['key'] === 'cubemap_uri' &&
-                data[i]['value'] !== undefined) {
+                data[i]['value'] !== null && data[i]['value'] !== undefined) {
               this.scene.addSky(data[i]['value'][0]);
+              break;
             }
           }
         } else {

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -358,8 +358,24 @@ export class SceneManager {
       }
 
       if ('sky' in sceneInfo && sceneInfo['sky']) {
-        this.scene.addSky();
+
+        const sky = sceneInfo['sky'];
+
+        // Check to see if a cubemap has been specified in the header.
+        if (sky['header'] !== undefined &&
+            sky['header']['data'] !== undefined) {
+          const data = sky['header']['data'];
+          for (let i = 0; i < data.length; ++i) {
+            if (data[i]['key'] === 'cubemap_uri' &&
+                data[i]['value'] !== undefined) {
+              this.scene.addSky(data[i]['value'][0]);
+            }
+          }
+        } else {
+          this.scene.addSky();
+        }
       }
+
       this.sceneInfo = sceneInfo;
       this.startVisualization();
 


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

As the name suggest, this is a quick hack to get a red skybox working. This approach will be replaced by proper `.dds` loading when I have more time.

Here is an example SDF file for testing:
```
<?xml version='1.0' encoding='utf-8'?>
<sdf version="1.9">
  <world name="test">
    <scene>
      <sky>
        <cubemap_uri>/home/nkoenig/skybox_red.dds</cubemap_uri>
      </sky>
    </scene>
    <model name="ground_plane">
      <static>true</static>
      <link name="link">
        <collision name="collision">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
              <size>100 100</size>
            </plane>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
              <size>100 100</size>
            </plane>
          </geometry>
          <material>
            <ambient>0.8 0.8 0.8 1</ambient>
            <diffuse>0.8 0.8 0.8 1</diffuse>
            <specular>0.8 0.8 0.8 1</specular>
          </material>
        </visual>
      </link>
    </model>
  </world>
</sdf>
```