### PR TITLE
Fix a problem with multiple audio messages coming in at once.

### DIFF
--- a/src/AudioTopic.ts
+++ b/src/AudioTopic.ts
@@ -5,13 +5,13 @@ import { Topic } from './Topic';
 export class AudioTopic {
 
   constructor(name: string, trans: Transport) {
-    let audioMap = new Map<string, typeof Audio>;
+    let audioMap = new Map<string, [HTMLAudioElement, boolean]>;
     let topic = new Topic(
       name,
       (msg) => {
         let playback = false;
         let uri = '';
-    
+
         // Get the playback and uri information.
         for (var key in msg.params) {
           if (key === 'playback') {
@@ -20,24 +20,33 @@ export class AudioTopic {
             uri = msg.params[key].string_value;
           }
         }
-    
+
         // Control audio playback if the audio file is in the audio map.
         if (uri in audioMap) {
-          if (playback) {
-            audioMap[uri].play();
+          const tuple = audioMap[uri];
+          if (tuple[1]) {
+            tuple[0].play();
           } else {
-            audioMap[uri].pause();
+            tuple[0].pause();
           }
+          tuple[1] = playback;
         // Otherwise, fetch the audio file
         } else {
           console.log('Getting audio file', uri);
+          // Fetching of the asset via getAsset() below is asynchronous, meaning
+          // that we could have requests for the same asset come in while we are
+          // fetching it.  To prevent multiple downloads and playing of the
+          // audio, add the uri to the map immediately with an empty object;
+          // we'll replace that dummy object with a fully active one once
+          // downloading the asset is complete.
+          audioMap[uri] = [new Audio(), playback];
           trans.getAsset(uri, (asset: Uint8Array) => {
             var audioSrc = 'data:audio/mp3;base64,' +
               binaryToBase64(asset);
             let audio = new Audio(audioSrc);
             audio.src = audioSrc;
-            audioMap[uri] = audio;
-            if (playback) {
+            audioMap[uri][0] = audio;
+            if (audioMap[uri][1]) {
               audio.play();
             }
           });


### PR DESCRIPTION
The problem is that currently, we fetch the asset asynchronously, and only then add it to the map.  That means that if other audio messages come in while we are fetching, we'll fetch the data more than once and then play it more than once.

Instead, this PR changes things so that as soon as we get a request for a new audio asset, we immediately add it to the map, then go fetch it asynchronously.  If other audio messages for the same asset come in, they will just harmlessly try to play audio that isn't there yet.  When we have finished downloading, we replace the object in the map with the fully active one which can be played.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>