### PR TITLE
Release 2.0.12-beta33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gzweb",
-  "version": "2.0.12-beta.32",
+  "version": "2.0.12-beta.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gzweb",
-      "version": "2.0.12-beta.32",
+      "version": "2.0.12-beta.33",
       "dependencies": {
         "eventemitter2": "^6.4.5",
         "jszip": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gzweb",
-  "version": "2.0.12-beta.32",
+  "version": "2.0.12-beta.33",
   "description": "A library for Gazebo and data visualization.",
   "type": "module",
   "main": "dist/gzweb.js",


### PR DESCRIPTION
This release fixes beta32, which included unwanted changes.

FYI @nkoenig . We need to be careful when running `npm publish`. We need to make sure we've built the changes intended for the release. My build had `debugger` lines when trying the skybox. Sorry for the additional noise.