### PR TITLE
Gzweb2 - Collada Color space and other fixes

### DIFF
--- a/include/ColladaLoader.js
+++ b/include/ColladaLoader.js
@@ -38,7 +38,7 @@ import {
 	Vector2,
 	Vector3,
 	VectorKeyframeTrack,
-	sRGBEncoding
+	LinearEncoding,
 } from 'three';
 import { TGALoader } from './TGALoader';
 
@@ -52,6 +52,8 @@ import { TGALoader } from './TGALoader';
  * previous versions of gzweb. Kept for backwards compatibility. If not used,
  * meshes that declare Z_UP have incorrect rotations, where we should have none.
  * The Y_UP prevents any further rotation from happening.
+ * - getTexture had an sRGB encoding. Changed to Linear encoding to maintain the
+ * behavior of previous versions.
  *
  * Diff of modification by Nate Koenig:
  *
@@ -1832,7 +1834,7 @@ class ColladaLoader extends Loader {
 
 					case 'diffuse':
 						if ( parameter.color ) material.color.fromArray( parameter.color );
-						if ( parameter.texture ) material.map = getTexture( parameter.texture, sRGBEncoding );
+						if ( parameter.texture ) material.map = getTexture( parameter.texture, LinearEncoding );
 						break;
 					case 'specular':
 						if ( parameter.color && material.specular ) material.specular.fromArray( parameter.color );
@@ -1842,23 +1844,25 @@ class ColladaLoader extends Loader {
 						if ( parameter.texture ) material.normalMap = getTexture( parameter.texture );
 						break;
 					case 'ambient':
-						if ( parameter.texture ) material.lightMap = getTexture( parameter.texture, sRGBEncoding );
+						if ( parameter.texture ) material.lightMap = getTexture( parameter.texture, LinearEncoding );
 						break;
 					case 'shininess':
 						if ( parameter.float && material.shininess ) material.shininess = parameter.float;
 						break;
 					case 'emission':
 						if ( parameter.color && material.emissive ) material.emissive.fromArray( parameter.color );
-						if ( parameter.texture ) material.emissiveMap = getTexture( parameter.texture, sRGBEncoding );
+						if ( parameter.texture ) material.emissiveMap = getTexture( parameter.texture, LinearEncoding );
 						break;
 
 				}
 
 			}
 
-			material.color.convertSRGBToLinear();
-			if ( material.specular ) material.specular.convertSRGBToLinear();
-			if ( material.emissive ) material.emissive.convertSRGBToLinear();
+			// Modified by German Mas.
+			// getTexture already uses Linear encoding. No need to convert.
+			// material.color.convertSRGBToLinear();
+			// if ( material.specular ) material.specular.convertSRGBToLinear();
+			// if ( material.emissive ) material.emissive.convertSRGBToLinear();
 
 			//
 

--- a/src/Material.ts
+++ b/src/Material.ts
@@ -2,11 +2,11 @@ import {Color} from './Color';
 import {PBRMaterial} from './PBRMaterial';
 
 export class Material {
-  public texture: string = ''; 
+  public texture: string = '';
   public normalMap: string = '';
-  public ambient: Color = new Color();
-  public diffuse: Color = new Color();
-  public specular: Color = new Color();
+  public ambient: Color | undefined;
+  public diffuse: Color | undefined;
+  public specular: Color | undefined;
   public opacity: number = 1.0;
   public scale: number = 1.0;
   public pbr: PBRMaterial;

--- a/src/SDFParser.ts
+++ b/src/SDFParser.ts
@@ -33,7 +33,7 @@ class PendingMesh {
   public meshUri: string = '';
   public submesh: string = '';
   public parent: THREE.Object3D;
-  public material: Material;
+  public material: Material | undefined;
   public centerSubmesh: boolean = false;
 }
 
@@ -203,7 +203,7 @@ export class SDFParser {
     let attConst: number = 0.0;
     let attLin: number = 0.0;
     let attQuad: number = 0.0;
-    let direction: THREE.Vector3 = new THREE.Vector3();
+    let direction: THREE.Vector3 | undefined;
     let innerAngle: number = 0.0;
     let outerAngle: number = 0.0;
     let falloff: number = 0.0;
@@ -418,12 +418,12 @@ export class SDFParser {
    * @returns {object} material - material object which has the followings:
    * texture, normalMap, ambient, diffuse, specular, opacity
    */
-  public createMaterial(srcMaterial: any): Material {
+  public createMaterial(srcMaterial: any): Material | undefined {
     var texture, mat;
     let material: Material = new Material();
 
     if (!srcMaterial) {
-      return material;
+      return undefined;
     }
 
     if (srcMaterial.ambient) {
@@ -979,7 +979,7 @@ export class SDFParser {
     }
 
     // Callback function when the mesh is ready.
-    function loadMesh(mesh: THREE.Mesh, material: Material,
+    function loadMesh(mesh: THREE.Mesh, material: Material | undefined,
                       parent: THREE.Object3D, ext: string) {
       if (!mesh) {
         console.error('Failed to load mesh.');


### PR DESCRIPTION
This PR applies some minor material and light-related fixes, as well as changing the color space encoding of the Collada Loader.

This achieves the goal of maintaining the visual look of the previous version.

Note: The following screenshots were captured using [this branch of GazeboApp](https://github.com/gazebo-web/gazebosim-app/pull/23). Make sure you use the latest changes of it.

---

## Color Spaces

See [Color Management at ThreeJS docs](https://threejs.org/docs/#manual/en/introduction/Color-management).

The Collada Loader used to have an encoding of `sRGBEncoding`, which replaced the original `LinearEncoding`. This caused our models to look different between our `gzweb` versions. This PR restores back the encoding to `LinearEncoding`.

## Other fixes

- Make `ambient`, `diffuse` and `specular` in `Material` to be optional. Otherwise, they had default values and incorrectly represented the parsed material.
- Allow `createMaterial` to return an undefined value if no material is passed. Otherwise, a material with default values was returned, which broke visuals.
- Make `direction` in `spawnLightFromSDF` be undefined instead of a default value of (0, 0, 0). If direction is defined, it is used as a spotlight target. Having a default value caused this logic to point all spotlights to the origin, which is not intended.

---

Can you ptal @nkoenig ?

---

## Screenshots

| Before | After |
| --- | --- |
| ![localhost_3000_gmas_fuel_worlds_Cave%20Simple%2003 (2)](https://github.com/gazebo-web/gzweb/assets/14120807/b1096a41-e747-48d2-a9aa-0b07e221dcb0) | ![localhost_3000_gmas_fuel_worlds_Cave%20Simple%2003](https://github.com/gazebo-web/gzweb/assets/14120807/cc230b23-a375-44de-b6b8-8417b0e6df18) |
| ![localhost_3000_gmas_fuel_models_TestPose3 (4)](https://github.com/gazebo-web/gzweb/assets/14120807/63569c49-1c3a-4e1d-a796-33e3518cba14) | ![localhost_3000_gmas_fuel_models_TestPose3 (5)](https://github.com/gazebo-web/gzweb/assets/14120807/35bfd274-2386-4eb4-a1d0-43e4e0e41a53) |


