### PR TITLE
SceneManager - Enable lights by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gzweb",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gzweb",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "dependencies": {
         "eventemitter2": "^6.4.5",
         "fast-xml-parser": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gzweb",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "A library for Gazebo and data visualization.",
   "type": "module",
   "main": "dist/gzweb.js",

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -47,6 +47,11 @@ export interface SceneManagerConfig {
    * Message data of the topic to advertise.
    */
   msgData?: any;
+
+  /**
+   * Whether or not lights in models are visible.
+   */
+  enableLights?: boolean;
 }
 
 /**
@@ -158,6 +163,10 @@ export class SceneManager {
    */
   private publisher: Publisher;
 
+  /*
+   * Whether or not lights in models are visible. Enabled by default.
+   */
+  private enableLights: boolean = true;
 
   /**
    * Constructor. If a url is specified, then then SceneManager will connect
@@ -185,6 +194,10 @@ export class SceneManager {
 
     if (config.websocketUrl) {
       this.connect(config.websocketUrl, config.websocketKey);
+    }
+
+    if (config.enableLights !== undefined) {
+      this.enableLights = config.enableLights;
     }
   }
 
@@ -383,7 +396,7 @@ export class SceneManager {
 
       sceneInfo['model'].forEach((model: any) => {
         const modelObj = this.sdfParser.spawnFromObj(
-          { model }, { enableLights: false });
+          { model }, { enableLights: this.enableLights });
 
         model['gz3dName'] = modelObj.name;
         this.models.push(model);
@@ -518,7 +531,7 @@ export class SceneManager {
           // update the models ID.
           if (foundIndex < 0) {
             const modelObj = this.sdfParser.spawnFromObj(
-              { model }, { enableLights: false });
+              { model }, { enableLights: this.enableLights });
             this.models.push(model);
             this.scene.add(modelObj);
           } else {


### PR DESCRIPTION
The `SceneManager` hid any lights from models. With this PR, now we make it to show lights by default.

A config can be sent to the `SceneManager` constructor if we don't want this behaviour (`new SceneManager({ enableLights: false })`)

Can you ptal @nkoenig ? This also includes a version bump (`2.0.14`)