### PR TITLE
Add missing primitive model support

### DIFF
--- a/src/SDFParser.ts
+++ b/src/SDFParser.ts
@@ -729,6 +729,12 @@ export class SDFParser {
       var length = parseFloat(geom.capsule.length);
       obj = this.scene.createCapsule(radius, length);
     }
+    else if (geom.cone)
+    {
+      var radius = parseFloat(geom.cone.radius);
+      var length = parseFloat(geom.cone.length);
+      obj = this.scene.createCone(radius, length);
+    }
     else if (geom.sphere)
     {
       obj = this.scene.createSphere(parseFloat(geom.sphere.radius));

--- a/src/SDFParser.ts
+++ b/src/SDFParser.ts
@@ -688,7 +688,7 @@ export class SDFParser {
    * object.
    * @param {object} geom - SDF geometry object which determines the geometry
    *  of the object and can have following properties: box, cylinder, sphere,
-   *  plane, mesh.
+   *  plane, mesh, capsule.
    *  Note that in case of using custom URLs for the meshes, the URLs should be
    *  added to the array customUrls to be used instead of the default URL.
    * @param {object} mat - SDF material object which is going to be parsed
@@ -722,6 +722,12 @@ export class SDFParser {
       var radius = parseFloat(geom.cylinder.radius);
       var length = parseFloat(geom.cylinder.length);
       obj = this.scene.createCylinder(radius, length);
+    }
+    else if (geom.capsule)
+    {
+      var radius = parseFloat(geom.capsule.radius);
+      var length = parseFloat(geom.capsule.length);
+      obj = this.scene.createCapsule(radius, length);
     }
     else if (geom.sphere)
     {
@@ -1865,7 +1871,12 @@ export class SDFParser {
     } else if (type === 'cylinder') {
       sdf = this.createCylinderSDF(translation, euler);
       modelObj = this.spawnFromSDF(sdf);
-    } else if (type === 'spotlight') {
+    } else if (type == 'capsule'){
+      sdf = this.createCapsuleSDF(translation, euler);
+      modelObj = this.spawnFromSDF(sdf);
+
+    } 
+    else if (type === 'spotlight') {
       modelObj = this.scene.createLight(2);
       this.scene.setPose(modelObj, translation, quaternion);
     } else if (type === 'directionallight') {
@@ -1901,9 +1912,9 @@ export class SDFParser {
   }
 
   /**
-   * Creates SDF string for simple shapes: box, cylinder, sphere.
+   * Creates SDF string for simple shapes: box, cylinder, sphere, capsule.
    * @param {string} type - type of the model which can be followings: box,
-   * sphere, cylinder
+   * sphere, cylinder, capsule
    * @param {THREE.Vector3} translation - denotes the x,y,z position
    * of the object
    * @param {THREE.Euler} euler - denotes the euler rotation of the object
@@ -1969,6 +1980,20 @@ export class SDFParser {
 
     return this.createSimpleShapeSDF('cylinder', translation, euler, geomSDF);
   }
+
+  /**
+   * Creates SDF string of capsule geometry element
+   * @param {THREE.Vector3} translation - the x,y,z position of
+   * the box object
+   * @param {THREE.Euler} euler - the euler rotation of the capsule object
+   * @returns {string} geomSDF - geometry SDF string of the capsule
+   */
+  public createCapsuleSDF(translation: THREE.Vector3, euler: THREE.Euler): string {
+    var geomSDF = '<capsule>' + '<radius>0.5</radius>' + '<length>1.0</length>'
+            + '</capsule>';
+    return this.createSimpleShapeSDF('capsule', translation, euler, geomSDF);
+  }
+
 
   /**
    * Set a request header for internal requests.

--- a/src/SDFParser.ts
+++ b/src/SDFParser.ts
@@ -689,8 +689,8 @@ export class SDFParser {
    * @param {object} geom - SDF geometry object which determines the geometry
    *  of the object and can have following properties: box, cylinder, sphere,
    *  plane, mesh.
-   *  Note that in case of using custom Urls for the meshs, the URLS should be
-   *  added to the array cistomUrls to be used instead of the default Url.
+   *  Note that in case of using custom URLs for the meshes, the URLs should be
+   *  added to the array customUrls to be used instead of the default URL.
    * @param {object} mat - SDF material object which is going to be parsed
    * by createMaterial function
    * @param {object} parent - parent 3D object

--- a/src/SDFParser.ts
+++ b/src/SDFParser.ts
@@ -735,6 +735,11 @@ export class SDFParser {
       var length = parseFloat(geom.cone.length);
       obj = this.scene.createCone(radius, length);
     }
+    else if (geom.ellipsoid)
+    {
+      var radii = this.parseSize(geom.ellipsoid.radii);
+      obj = this.scene.createEllipsoid(radii.x, radii.y, radii.z);
+    }
     else if (geom.sphere)
     {
       obj = this.scene.createSphere(parseFloat(geom.sphere.radius));

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -1440,6 +1440,19 @@ export class Scene {
   }
 
   /**
+   * Create capsule
+   * @param {double} radius
+   * @param {double} length
+   * @returns {THREE.Mesh}
+   */
+  public createCapsule(radius: number, length: number): THREE.Mesh {
+    var geometry = new THREE.CapsuleGeometry(radius, length, 32, 16);
+    var mesh = new THREE.Mesh(geometry, this.simpleShapesMaterial);
+    mesh.rotation.x = Math.PI * 0.5;
+    return mesh;
+  }
+
+  /**
    * Create box
    * @param {double} width
    * @param {double} height

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -1466,6 +1466,20 @@ export class Scene {
   }
 
   /**
+   * Create ellipsoid
+   * @param {double} radius
+   * @param {double} length
+   * @returns {THREE.Mesh}
+   */
+  public createEllipsoid(radius1: number, radius2: number, radius3: number): THREE.Mesh {
+    var geometry = new THREE.SphereGeometry(radius1, 32, 32);
+    geometry.scale(1, radius3/radius1, radius2/radius1);
+    var mesh = new THREE.Mesh(geometry, this.simpleShapesMaterial);
+    mesh.rotation.x = Math.PI * 0.5;
+    return mesh;
+  }
+
+  /**
    * Create box
    * @param {double} width
    * @param {double} height

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -1453,6 +1453,19 @@ export class Scene {
   }
 
   /**
+   * Create cone
+   * @param {double} radius
+   * @param {double} length
+   * @returns {THREE.Mesh}
+   */
+  public createCone(radius: number, length: number): THREE.Mesh {
+    var geometry = new THREE.ConeGeometry(radius, length, 32);
+    var mesh = new THREE.Mesh(geometry, this.simpleShapesMaterial);
+    mesh.rotation.x = Math.PI * 0.5;
+    return mesh;
+  }
+
+  /**
    * Create box
    * @param {double} width
    * @param {double} height

--- a/src/SpawnModel.ts
+++ b/src/SpawnModel.ts
@@ -63,6 +63,8 @@ export class SpawnModel {
       meshLoaded(this.scene.createSphere(0.5), true);
     } else if (entity === 'cylinder') {
       meshLoaded(this.scene.createCylinder(0.5, 1.0), true);
+    }else if (entity === 'capsule') {
+      meshLoaded(this.scene.createCapsule(1, 1), true);
     } else if (entity === 'pointlight') {
       meshLoaded(this.scene.createLight(1), false);
     } else if (entity === 'spotlight') {


### PR DESCRIPTION
This adds support for `cone`, `capsule`, and `ellipsoid`. 

Here it is shown with `shapes.sdf` : 
![image](https://github.com/user-attachments/assets/e232af34-1ac4-4828-b7f0-6ae79da95ead)
